### PR TITLE
State machine

### DIFF
--- a/Data/IO/Type.agda
+++ b/Data/IO/Type.agda
@@ -3,6 +3,5 @@ module Data.IO.Type where
 postulate IO : Set → Set
 {-# BUILTIN IO IO #-}
 {-# COMPILE GHC IO = type IO #-}
-
 {-# FOREIGN GHC import qualified Data.Text.IO as Text #-}
 {-# COMPILE JS IO = function(x) { return x; } #-}

--- a/Data/IO/Type.agda
+++ b/Data/IO/Type.agda
@@ -3,5 +3,6 @@ module Data.IO.Type where
 postulate IO : Set → Set
 {-# BUILTIN IO IO #-}
 {-# COMPILE GHC IO = type IO #-}
+
 {-# FOREIGN GHC import qualified Data.Text.IO as Text #-}
 {-# COMPILE JS IO = function(x) { return x; } #-}

--- a/Data/IO/seq.agda
+++ b/Data/IO/seq.agda
@@ -1,0 +1,13 @@
+module Data.IO.seq where
+
+open import Data.IO.Type
+open import Data.IO.bind
+
+-- Sequential composition of IO actions
+-- - m1: The first IO action to be performed
+-- - m2: The second IO action to be performed
+-- = An IO action that performs m1 and then m2, discarding the result of m1
+_>>_ : {A B : Set} → IO A → IO B → IO B
+m1 >> m2 = m1 >>= λ _ → m2
+
+infixl 1 _>>_

--- a/Data/Map/count.agda
+++ b/Data/Map/count.agda
@@ -1,0 +1,17 @@
+module Data.Map.count where
+
+open import Data.Map.Type
+open import Data.Nat.Type
+open import Data.Nat.show
+open import Data.Nat.add
+open import Data.Maybe.Type
+open import Data.String.Type
+
+-- Counts the number of elements in a Map.
+-- - m: The Map to count elements from.
+-- = The number of elements in the Map.
+count : ∀ {A : Set} → Map A → Nat
+count Leaf = Zero
+count (Node None left right) = count left + count right
+count (Node (Some _) left right) = Succ (count left + count right)
+

--- a/Data/Map/remove.agda
+++ b/Data/Map/remove.agda
@@ -1,0 +1,16 @@
+module Data.Map.remove where
+
+open import Data.Map.Type
+open import Data.Bits.Type
+open import Data.Maybe.Type
+open import Data.Tree.Type
+
+-- Removes a key-value pair from the Map.
+-- - m: The Map to remove from.
+-- - k: The Bits key to remove.
+-- = A new Map with the key-value pair removed.
+remove : ∀ {A : Set} → Map A → Bits → Map A
+remove (Node val lft rgt) E     = Node None lft rgt
+remove (Node val lft rgt) (O k) = Node val (remove lft k) rgt
+remove (Node val lft rgt) (I k) = Node val lft (remove rgt k)
+remove Leaf               _     = Leaf

--- a/Data/Nat/gte.agda
+++ b/Data/Nat/gte.agda
@@ -1,0 +1,17 @@
+module Data.Nat.gte where
+
+open import Data.Nat.Type
+open import Data.Bool.Type
+open import Data.Bool.or
+open import Data.Nat.eq
+open import Data.Nat.gt
+
+-- Greater-than-or-equal-to comparison for nats.
+-- - x: The 1st nat.
+-- - y: The 2nd nat.
+-- = True if x is greater than or equal to y.
+gte : Nat → Nat → Bool
+gte x y = (x == y) || (x > y)
+
+_>=_ : Nat → Nat → Bool
+_>=_ = gte

--- a/Data/Nat/lte.agda
+++ b/Data/Nat/lte.agda
@@ -1,0 +1,17 @@
+module Data.Nat.lte where
+
+open import Data.Nat.Type
+open import Data.Bool.Type
+open import Data.Bool.or
+open import Data.Nat.eq
+open import Data.Nat.lt
+
+-- Less-than-or-equal-to comparison for nats.
+-- - x: The 1st nat.
+-- - y: The 2nd nat.
+-- = True if x is less than or equal to y.
+lte : Nat → Nat → Bool
+lte x y = (x == y) || (x < y)
+
+_<=_ : Nat → Nat → Bool
+_<=_ = lte

--- a/Data/Nat/max.agda
+++ b/Data/Nat/max.agda
@@ -1,0 +1,12 @@
+module Data.Nat.max where
+
+open import Data.Nat.Type
+open import Data.Nat.gte
+open import Data.Bool.if
+
+-- Returns the maximum of two natural numbers.
+-- - x: The first natural number.
+-- - y: The second natural number.
+-- = The larger of x and y.
+max : Nat → Nat → Nat
+max x y = if x >= y then x else y

--- a/Data/Nat/min.agda
+++ b/Data/Nat/min.agda
@@ -1,0 +1,12 @@
+module Data.Nat.min where
+
+open import Data.Nat.Type
+open import Data.Nat.lte
+open import Data.Bool.if
+
+-- Returns the minimum of two natural numbers.
+-- - x: The first natural number.
+-- - y: The second natural number.
+-- = The smaller of x and y.
+min : Nat → Nat → Nat
+min x y = if x <= y then x else y

--- a/Data/Nat/to-bits.agda
+++ b/Data/Nat/to-bits.agda
@@ -1,0 +1,30 @@
+{-# OPTIONS --no-termination-check #-}
+module Data.Nat.to-bits where
+
+open import Data.Nat.Type
+open import Data.Bits.Type
+open import Data.Nat.div
+open import Data.Nat.mod
+open import Data.Nat.eq
+open import Data.Bool.if
+
+-- Helper function for to_bits that handles the recursive case.
+-- - n: The remaining part of the natural number to convert.
+-- = The binary representation of the number as Bits.
+to-bits-helper : Nat → Bits
+to-bits-helper Zero = O E
+to-bits-helper (Succ n) =
+  let quotient = div (Succ n) 2
+      remainder = mod (Succ n) 2
+  in if (remainder == Zero)
+     then O (to-bits-helper quotient)
+     else I (to-bits-helper quotient)
+
+-- Converts a natural number to its binary representation.
+-- - n: The natural number to convert.
+-- = The binary representation of the number as Bits.
+to-bits : Nat → Bits
+to-bits Zero = O E
+to-bits (Succ n) = to-bits-helper (Succ n)
+
+

--- a/Data/Nat/to-bits.agda
+++ b/Data/Nat/to-bits.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --no-termination-check #-}
 module Data.Nat.to-bits where
 
 open import Data.Nat.Type

--- a/UG/Main.agda
+++ b/UG/Main.agda
@@ -1,0 +1,95 @@
+module UG.Main where
+
+open import UG.SM.Type
+open import UG.SM.Game.Type
+open import UG.SM.new-mach
+open import UG.SM.register-action
+open import UG.SM.compute
+open import UG.SM.Time.Type
+open import UG.SM.TimedAction.Type
+open import UG.SM.Time.time-to-tick
+
+open import Data.Nat.Type
+open import Data.Nat.show
+open import Data.Bool.Type
+open import Data.String.Type
+open import Data.IO.seq
+open import Data.String.append
+open import Data.IO.Type
+open import Data.IO.put-str-ln
+open import Data.Unit.Type
+open import Data.Maybe.Type
+open import Data.List.Type
+
+open import Data.Map.Type
+open import Data.Map.new
+open import Data.Map.set
+open import Data.Map.count
+open import Data.Bits.Type
+
+-- Simple game state
+data GameState : Set where
+  Score : Nat → GameState
+
+-- Simple game action
+data GameAction : Set where
+  AddPoint : GameAction
+
+-- Game definition
+game : Game GameState GameAction
+game = record
+  { init = Score 0
+  ; when = λ { AddPoint (Score n) → Score (Succ n) }
+  ; tick = λ { (Score n) → Score (n) }  -- Increment score on each tick
+  }
+
+-- Action equality function
+action-eq : GameAction → GameAction → Bool
+action-eq AddPoint AddPoint = False
+
+gameStateToString : GameState → String
+gameStateToString (Score n) = "Score " ++ show n
+
+-- Debug log function
+debug-log : String → IO Unit
+debug-log = put-str-ln
+
+-- Test function
+test : IO Unit
+test = do
+  debug-log "Starting test..."
+  
+  let initial-mach = new-mach 1000 action-eq
+  debug-log ("Initial machine created with " ++ show (Mach.ticks-per-second initial-mach) ++ " ticks per second")
+  debug-log ("Initial machine logs: " ++ show (count (Mach.action-logs initial-mach)))
+  
+  let mach1 = register-action initial-mach (record { action = AddPoint ; time = 5 })
+  debug-log "Registered AddPoint action at time 5"
+  debug-log ("Action logs count after first action: " ++ show (count (Mach.action-logs mach1)))
+  
+  let mach2 = register-action mach1 (record { action = AddPoint ; time = 15 })
+  debug-log "Registered AddPoint action at time 15"
+  debug-log ("Action logs count after second action: " ++ show (count (Mach.action-logs mach2)))
+ 
+  -- Compute calls
+  let state0 = compute mach2 game 0
+  debug-log ("State at time 0: " ++ gameStateToString state0)
+  
+  let state5 = compute mach2 game 5
+  debug-log ("State at time 5: " ++ gameStateToString state5)
+  
+  let state10 = compute mach2 game 10
+  debug-log ("State at time 10: " ++ gameStateToString state10)
+  
+  let state15 = compute mach2 game 15
+  debug-log ("State at time 15: " ++ gameStateToString state15)
+  
+  let state20 = compute mach2 game 20
+  debug-log ("State at time 20: " ++ gameStateToString state20)
+
+  debug-log "Test completed."
+
+-- Main function
+main : IO Unit
+main = do
+  test

--- a/UG/SM/ActionLogs/Type.agda
+++ b/UG/SM/ActionLogs/Type.agda
@@ -1,0 +1,14 @@
+module UG.SM.ActionLogs.Type where
+
+open import Data.Map.Type
+open import Data.List.Type
+open import Data.Map.get
+open import Data.Map.set
+open import Data.Nat.to-bits
+open import Data.Maybe.Type
+open import Data.List.append
+
+open import UG.SM.Tick.Type
+
+ActionLogs : Set → Set
+ActionLogs A = Map (List A)

--- a/UG/SM/ActionLogs/add-action.agda
+++ b/UG/SM/ActionLogs/add-action.agda
@@ -1,0 +1,25 @@
+module UG.SM.ActionLogs.add-action where
+
+open import UG.SM.Tick.Type
+open import UG.SM.ActionLogs.Type
+
+open import Data.Map.Type
+open import Data.List.Type
+open import Data.Map.get
+open import Data.Map.set
+open import Data.Nat.to-bits
+open import Data.Maybe.Type
+open import Data.List.append
+
+-- Adds an action to the ActionLogs at a specific tick.
+-- If the tick already has a list of actions, the new action is appended to that list.
+-- If the tick doesn't exist, a new list with the single action is created.
+-- - logs: The original ActionLogs.
+-- - t: The tick at which to add the action.
+-- - a: The action to add.
+-- = A new ActionLogs with the action added at the specified tick.
+add-action : ∀ {A : Set} → ActionLogs A → Tick → A → ActionLogs A
+add-action logs t a with get logs (to-bits t)
+... | None         = set logs (to-bits t) (a :: [])
+... | Some actions = set logs (to-bits t) (actions ++ (a :: []))
+

--- a/UG/SM/ActionLogs/get-actions.agda
+++ b/UG/SM/ActionLogs/get-actions.agda
@@ -1,0 +1,19 @@
+module UG.SM.ActionLogs.get-actions where
+
+open import Data.List.Type
+open import Data.Map.get
+open import Data.Nat.to-bits
+open import Data.Maybe.Type
+
+open import UG.SM.Tick.Type
+open import UG.SM.ActionLogs.Type
+
+-- Retrieves the list of actions for a specific tick from the ActionLogs.
+-- If no actions exist for the given tick, returns an empty list.
+-- - logs: The ActionLogs to retrieve actions from.
+-- - t: The tick for which to retrieve actions.
+-- = The list of actions for the specified tick, or an empty list if none exist.
+get-actions : ∀ {A : Set} → ActionLogs A → Tick → List A
+get-actions logs t with get logs (to-bits t)
+... | None         = []
+... | Some actions = actions

--- a/UG/SM/Game/Type.agda
+++ b/UG/SM/Game/Type.agda
@@ -1,0 +1,7 @@
+module UG.SM.Game.Type where
+
+record Game (S A : Set) : Set where
+  field
+    init : S
+    when : A → S → S
+    tick : S → S

--- a/UG/SM/Main.agda
+++ b/UG/SM/Main.agda
@@ -1,4 +1,4 @@
-module UG.Main where
+module UG.SM.Main where
 
 open import UG.SM.Type
 open import UG.SM.Game.Type

--- a/UG/SM/StateLogs/Type.agda
+++ b/UG/SM/StateLogs/Type.agda
@@ -1,0 +1,25 @@
+module UG.SM.StateLogs.Type where
+
+open import UG.SM.Tick.Type
+
+open import Data.Map.Type
+open import Data.Map.remove
+open import Data.Nat.Type
+open import Data.Nat.lt
+open import Data.Nat.to-bits
+open import Data.Nat.add
+open import Data.Bool.if
+
+StateLogs : Set → Set
+StateLogs S = Map S
+
+-- Removes state logs for ticks in the range (start_tick, end_tick].
+-- - logs: The initial StateLogs.
+-- - start_tick: The tick to start removing from (exclusive).
+-- - end_tick: The tick to stop removing at (inclusive).
+-- = The updated StateLogs with entries removed.
+remove-range : ∀ {S : Set} → StateLogs S → Tick → Tick → StateLogs S
+remove-range logs start_tick end_tick =
+  if start_tick < end_tick
+  then remove-range (remove logs (to-bits (Succ start_tick))) (Succ start_tick) end_tick
+  else logs

--- a/UG/SM/StateLogs/Type.agda
+++ b/UG/SM/StateLogs/Type.agda
@@ -10,16 +10,6 @@ open import Data.Nat.to-bits
 open import Data.Nat.add
 open import Data.Bool.if
 
+-- Maps from bit indices to States
 StateLogs : Set → Set
 StateLogs S = Map S
-
--- Removes state logs for ticks in the range (start_tick, end_tick].
--- - logs: The initial StateLogs.
--- - start_tick: The tick to start removing from (exclusive).
--- - end_tick: The tick to stop removing at (inclusive).
--- = The updated StateLogs with entries removed.
-remove-range : ∀ {S : Set} → StateLogs S → Tick → Tick → StateLogs S
-remove-range logs start_tick end_tick =
-  if start_tick < end_tick
-  then remove-range (remove logs (to-bits (Succ start_tick))) (Succ start_tick) end_tick
-  else logs

--- a/UG/SM/StateLogs/remove-range.agda
+++ b/UG/SM/StateLogs/remove-range.agda
@@ -1,0 +1,22 @@
+module UG.SM.StateLogs.remove-range where
+
+open import UG.SM.StateLogs.Type
+open import UG.SM.Tick.Type
+
+open import Data.Map.Type
+open import Data.Map.remove
+open import Data.Nat.Type
+open import Data.Nat.lt
+open import Data.Nat.to-bits
+open import Data.Bool.if
+
+-- Removes state logs for ticks in the range (start_tick, end_tick].
+-- - logs: The initial StateLogs.
+-- - start_tick: The tick to start removing from (exclusive).
+-- - end_tick: The tick to stop removing at (inclusive).
+-- = The updated StateLogs with entries removed.
+remove-range : ∀ {S : Set} → StateLogs S → Tick → Tick → StateLogs S
+remove-range logs start_tick end_tick =
+  if start_tick < end_tick
+  then remove-range (remove logs (to-bits (Succ start_tick))) (Succ start_tick) end_tick
+  else logs

--- a/UG/SM/Tick/Type.agda
+++ b/UG/SM/Tick/Type.agda
@@ -1,0 +1,7 @@
+module UG.SM.Tick.Type where
+
+open import Data.Nat.Type
+
+-- Represents a tick value
+Tick : Set
+Tick = Nat

--- a/UG/SM/Time/Type.agda
+++ b/UG/SM/Time/Type.agda
@@ -1,0 +1,7 @@
+module UG.SM.Time.Type where
+
+open import Data.Nat.Type
+
+-- Represents a time value
+Time : Set
+Time = Nat

--- a/UG/SM/Time/time-to-tick.agda
+++ b/UG/SM/Time/time-to-tick.agda
@@ -1,0 +1,17 @@
+module UG.SM.Time.time-to-tick where
+
+open import UG.SM.Type
+open import UG.SM.Time.Type
+open import UG.SM.Tick.Type
+
+open import Data.Nat.Type
+open import Data.Nat.div
+open import Data.Nat.mul
+
+-- Converts a Time value to a Tick value for a given state machine.
+-- - mach: The state machine.
+-- - time: The time to convert.
+-- = The corresponding Tick value.
+time-to-tick : ∀ {S A : Set} → Mach S A → Time → Tick
+time-to-tick mach time = 
+  div (mul time (Mach.ticks-per-second mach)) 1000

--- a/UG/SM/TimedAction/Type.agda
+++ b/UG/SM/TimedAction/Type.agda
@@ -1,0 +1,9 @@
+module UG.SM.TimedAction.Type where
+
+open import UG.SM.Time.Type
+
+-- Represents an action with a time
+record TimedAction (A : Set) : Set where
+  field
+    action : A
+    time : Time

--- a/UG/SM/TimedAction/Type.agda
+++ b/UG/SM/TimedAction/Type.agda
@@ -2,7 +2,7 @@ module UG.SM.TimedAction.Type where
 
 open import UG.SM.Time.Type
 
--- Represents an action with a time
+-- Used to bind an action to a timestamp
 record TimedAction (A : Set) : Set where
   field
     action : A

--- a/UG/SM/Type.agda
+++ b/UG/SM/Type.agda
@@ -7,6 +7,16 @@ open import UG.SM.ActionLogs.Type
 open import Data.Nat.Type
 open import Data.Bool.Type
 
+-- S : The type of states in the state machine
+-- A : The type of actions that can be performed on the state machine
+-- = A record type representing a state machine
+-- Fields:
+--   ticks-per-second : The number of ticks that occur in one second
+--   genesis-tick : The initial tick value when the machine was created
+--   cached-tick : The most recently processed tick
+--   state-logs : A log of states indexed by ticks
+--   action-logs : A log of actions indexed by ticks
+--   action-eq : A function to compare two actions for equality
 record Mach (S A : Set) : Set where
   field
     ticks-per-second : Nat

--- a/UG/SM/Type.agda
+++ b/UG/SM/Type.agda
@@ -1,0 +1,17 @@
+module UG.SM.Type where
+
+open import UG.SM.Tick.Type
+open import UG.SM.StateLogs.Type
+open import UG.SM.ActionLogs.Type
+
+open import Data.Nat.Type
+open import Data.Bool.Type
+
+record Mach (S A : Set) : Set where
+  field
+    ticks-per-second : Nat
+    genesis-tick : Tick
+    cached-tick : Tick
+    state-logs : StateLogs S
+    action-logs : ActionLogs A
+    action-eq : A → A → Bool

--- a/UG/SM/action-in-list.agda
+++ b/UG/SM/action-in-list.agda
@@ -1,0 +1,11 @@
+module UG.SM.action-in-list where
+
+open import UG.SM.Type
+open import Data.List.Type
+open import Data.Bool.Type
+open import Data.Bool.or
+
+-- Checks if an action is already in the list using the machine's action-eq function
+action-in-list : ∀ {S A : Set} → Mach S A → A → List A → Bool
+action-in-list _ _ [] = False
+action-in-list mach a (x :: xs) = (Mach.action-eq mach a x) || action-in-list mach a xs

--- a/UG/SM/action-in-list.agda
+++ b/UG/SM/action-in-list.agda
@@ -5,7 +5,10 @@ open import Data.List.Type
 open import Data.Bool.Type
 open import Data.Bool.or
 
--- Checks if an action is already in the list using the machine's action-eq function
+-- mach : The machine containing the action equality function
+-- a    : The action to search for
+-- as   : The list of actions to search in
+-- = Bool, True if the action is found, False otherwise
 action-in-list : ∀ {S A : Set} → Mach S A → A → List A → Bool
-action-in-list _ _ [] = False
+action-in-list _ _ []           = False
 action-in-list mach a (x :: xs) = (Mach.action-eq mach a x) || action-in-list mach a xs

--- a/UG/SM/add-action-to-logs.agda
+++ b/UG/SM/add-action-to-logs.agda
@@ -1,0 +1,11 @@
+module UG.SM.add-action-to-logs where
+
+open import UG.SM.Type
+open import UG.SM.Tick.Type
+open import UG.SM.ActionLogs.Type
+open import UG.SM.ActionLogs.add-action
+
+-- Add an action to the action logs
+add-action-to-logs : ∀ {S A : Set} → Mach S A → Tick → A → Mach S A
+add-action-to-logs mach tick action =
+  record mach { action-logs = add-action (Mach.action-logs mach) tick action }

--- a/UG/SM/add-action-to-logs.agda
+++ b/UG/SM/add-action-to-logs.agda
@@ -5,7 +5,10 @@ open import UG.SM.Tick.Type
 open import UG.SM.ActionLogs.Type
 open import UG.SM.ActionLogs.add-action
 
--- Add an action to the action logs
+-- mach: The machine state to update
+-- tick: The tick at which the action occurred
+-- action: The action to add to the logs
+-- = An updated Mach S A with the new action added to its action logs
 add-action-to-logs : ∀ {S A : Set} → Mach S A → Tick → A → Mach S A
 add-action-to-logs mach tick action =
   record mach { action-logs = add-action (Mach.action-logs mach) tick action }

--- a/UG/SM/compute.agda
+++ b/UG/SM/compute.agda
@@ -1,0 +1,69 @@
+module UG.SM.compute where
+
+open import UG.SM.Type
+open import UG.SM.Game.Type
+open import UG.SM.Tick.Type
+open import UG.SM.StateLogs.Type
+open import UG.SM.ActionLogs.Type
+open import UG.SM.ActionLogs.get-actions
+open import UG.SM.Time.Type
+open import UG.SM.Time.time-to-tick
+
+open import Data.Bool.if
+open import Data.Nat.Type
+open import Data.Nat.eq
+open import Data.Nat.max
+open import Data.Nat.lt
+open import Data.Function.case using (case_of_)
+open import Data.List.Type
+open import Data.List.fold
+open import Data.Maybe.Type
+open import Data.Map.get
+open import Data.Map.set
+open import Data.Nat.to-bits
+open import Data.Nat.sub
+open import Data.Nat.gt
+
+-- Helper function to get initial state
+get-initial-state : ∀ {S A : Set} → Mach S A → Game S A → Tick → S
+get-initial-state mach game ini-t =
+  case get (Mach.state-logs mach) (to-bits ini-t) of
+    λ { (Some state) → state
+      ; Nothing      → Game.init game
+      }
+
+update-mach : ∀ {S A : Set} → Mach S A → Tick → S → Mach S A
+update-mach mach t s =
+  record mach
+    { cached-tick = max (Mach.cached-tick mach) t
+    ; state-logs = set (Mach.state-logs mach) (to-bits t) s
+    }
+
+-- Helper function to recursively compute the state
+compute-helper : ∀ {S A : Set} → Mach S A → Game S A → S → Tick → Tick → S
+compute-helper mach game state current-tick end-tick =
+  if current-tick == end-tick
+  then state
+  else 
+    let next-tick = Succ current-tick
+        actions = get-actions (Mach.action-logs mach) current-tick
+        state-with-actions = fold (Game.when game) state actions
+        next-state = Game.tick game state-with-actions
+        updated-mach = update-mach mach current-tick state
+    in compute-helper updated-mach game next-state next-tick end-tick
+
+-- Computes the state of the game at a given time
+-- - mach: The state machine
+-- - game: The game rules
+-- - time: The target time
+-- = The computed state at the given time
+compute : ∀ {S A : Set} → Mach S A → Game S A → Time → S
+compute mach game time =
+  let ini-t = Mach.cached-tick mach
+      end-t = time-to-tick mach time
+      initial-state = get-initial-state mach game ini-t
+  in
+  if (end-t - ini-t) > 1000
+  then initial-state
+  else compute-helper mach game initial-state ini-t end-t
+

--- a/UG/SM/compute.agda
+++ b/UG/SM/compute.agda
@@ -8,6 +8,8 @@ open import UG.SM.ActionLogs.Type
 open import UG.SM.ActionLogs.get-actions
 open import UG.SM.Time.Type
 open import UG.SM.Time.time-to-tick
+open import UG.SM.update-mach
+open import UG.SM.get-initial-state
 
 open import Data.Bool.if
 open import Data.Nat.Type
@@ -24,22 +26,12 @@ open import Data.Nat.to-bits
 open import Data.Nat.sub
 open import Data.Nat.gt
 
--- Helper function to get initial state
-get-initial-state : ∀ {S A : Set} → Mach S A → Game S A → Tick → S
-get-initial-state mach game ini-t =
-  case get (Mach.state-logs mach) (to-bits ini-t) of
-    λ { (Some state) → state
-      ; Nothing      → Game.init game
-      }
-
-update-mach : ∀ {S A : Set} → Mach S A → Tick → S → Mach S A
-update-mach mach t s =
-  record mach
-    { cached-tick = max (Mach.cached-tick mach) t
-    ; state-logs = set (Mach.state-logs mach) (to-bits t) s
-    }
-
--- Helper function to recursively compute the state
+-- mach: The state machine
+-- game: The game rules
+-- state: The current state
+-- current-tick: The current tick
+-- end-tick: The target tick
+-- = The computed state at the end tick
 compute-helper : ∀ {S A : Set} → Mach S A → Game S A → S → Tick → Tick → S
 compute-helper mach game state current-tick end-tick =
   if current-tick == end-tick
@@ -53,9 +45,9 @@ compute-helper mach game state current-tick end-tick =
     in compute-helper updated-mach game next-state next-tick end-tick
 
 -- Computes the state of the game at a given time
--- - mach: The state machine
--- - game: The game rules
--- - time: The target time
+-- mach: The state machine
+-- game: The game rules
+-- time: The target time
 -- = The computed state at the given time
 compute : ∀ {S A : Set} → Mach S A → Game S A → Time → S
 compute mach game time =
@@ -66,4 +58,3 @@ compute mach game time =
   if (end-t - ini-t) > 1000
   then initial-state
   else compute-helper mach game initial-state ini-t end-t
-

--- a/UG/SM/get-initial-state.agda
+++ b/UG/SM/get-initial-state.agda
@@ -1,0 +1,24 @@
+module UG.SM.get-initial-state where
+
+open import UG.SM.Type
+open import UG.SM.Game.Type
+open import UG.SM.Tick.Type
+open import UG.SM.StateLogs.Type
+
+open import Data.Function.case using (case_of_)
+open import Data.Map.get
+open import Data.Map.set
+open import Data.Nat.to-bits
+open import Data.Maybe.Type
+
+-- get-initial-state: Helper function to get initial state
+-- mach: The machine containing state logs
+-- game: The game object with an init function
+-- ini-t: The initial tick
+-- = Returns the initial state of type S
+get-initial-state : ∀ {S A : Set} → Mach S A → Game S A → Tick → S
+get-initial-state mach game ini-t =
+  case get (Mach.state-logs mach) (to-bits ini-t) of
+    λ { (Some state) → state
+      ; Nothing      → Game.init game
+      }

--- a/UG/SM/new-mach.agda
+++ b/UG/SM/new-mach.agda
@@ -1,0 +1,24 @@
+module UG.SM.new-mach where
+
+open import UG.SM.Type
+open import UG.SM.Tick.Type
+open import UG.SM.StateLogs.Type
+open import UG.SM.ActionLogs.Type
+
+open import Data.Nat.Type
+open import Data.Map.new
+open import Data.Bool.Type
+
+-- Creates a new Mach (state machine) with the given ticks per second and action equality function.
+-- - ticks_per_second: The number of ticks per second for this machine.
+-- - action_eq: A function to compare two actions for equality.
+-- = A new Mach instance with default values and the provided action equality function.
+new_mach : ∀ {S A : Set} → Nat → (A → A → Bool) → Mach S A
+new_mach ticks-per-second action_eq = record
+  { ticks-per-second = ticks-per-second
+  ; genesis-tick = 0  -- Representing the earliest possible tick
+  ; cached-tick = 0   -- Representing no cached tick
+  ; state-logs = new
+  ; action-logs = new
+  ; action-eq = action_eq
+  }

--- a/UG/SM/new-mach.agda
+++ b/UG/SM/new-mach.agda
@@ -13,10 +13,10 @@ open import Data.Bool.Type
 -- - ticks_per_second: The number of ticks per second for this machine.
 -- - action_eq: A function to compare two actions for equality.
 -- = A new Mach instance with default values and the provided action equality function.
-new_mach : ∀ {S A : Set} → Nat → (A → A → Bool) → Mach S A
-new_mach ticks-per-second action_eq = record
+new-mach : ∀ {S A : Set} → Nat → (A → A → Bool) → Mach S A
+new-mach ticks-per-second action_eq = record
   { ticks-per-second = ticks-per-second
-  ; genesis-tick = 0  -- Representing the earliest possible tick
+  ; genesis-tick = 100000  -- Representing the earliest possible tick
   ; cached-tick = 0   -- Representing no cached tick
   ; state-logs = new
   ; action-logs = new

--- a/UG/SM/register-action.agda
+++ b/UG/SM/register-action.agda
@@ -28,6 +28,9 @@ open import Data.Bool.Type
 open import Data.Bool.if
 open import Data.Bool.or
 
+-- mach: The current state machine
+-- timedAction: The action to be registered, containing the action and its associated time
+-- = Returns an updated state machine with the new action registered
 register-action : ∀ {S A : Set} → Mach S A → TimedAction A → Mach S A
 register-action mach (record { action = action ; time = time }) =
   let tick = time-to-tick mach time
@@ -35,4 +38,3 @@ register-action mach (record { action = action ; time = time }) =
       mach2 = update-cached-tick mach1 tick
       mach3 = remove-future-states mach2 tick
   in add-action-to-logs mach3 tick action
-

--- a/UG/SM/register-action.agda
+++ b/UG/SM/register-action.agda
@@ -31,14 +31,8 @@ open import Data.Bool.or
 register-action : ∀ {S A : Set} → Mach S A → TimedAction A → Mach S A
 register-action mach (record { action = action ; time = time }) =
   let tick = time-to-tick mach time
-      actions = get-actions (Mach.action-logs mach) tick
-  in if action-in-list mach action actions
-     then mach
-     else (add-action-to-logs 
-            (remove-future-states 
-              (update-cached-tick 
-                (update-genesis-tick mach tick) 
-              tick) 
-            tick) 
-          tick 
-          action)
+      mach1 = update-genesis-tick mach tick
+      mach2 = update-cached-tick mach1 tick
+      mach3 = remove-future-states mach2 tick
+  in add-action-to-logs mach3 tick action
+

--- a/UG/SM/register-action.agda
+++ b/UG/SM/register-action.agda
@@ -1,0 +1,44 @@
+module UG.SM.register-action where
+
+open import UG.SM.Type
+open import UG.SM.Time.Type
+open import UG.SM.Tick.Type
+open import UG.SM.Time.time-to-tick
+open import UG.SM.StateLogs.Type
+open import UG.SM.ActionLogs.Type
+open import UG.SM.ActionLogs.add-action
+open import UG.SM.ActionLogs.get-actions
+open import UG.SM.TimedAction.Type
+open import UG.SM.action-in-list
+open import UG.SM.update-genesis-tick
+open import UG.SM.update-cached-tick
+open import UG.SM.remove-future-states
+open import UG.SM.add-action-to-logs
+
+open import Data.Nat.Type
+open import Data.Nat.lt
+open import Data.Nat.eq
+open import Data.Nat.sub
+open import Data.List.Type
+open import Data.List.filter
+open import Data.Maybe.Type
+open import Data.String.Type
+open import Data.String.eq
+open import Data.Bool.Type
+open import Data.Bool.if
+open import Data.Bool.or
+
+register-action : ∀ {S A : Set} → Mach S A → TimedAction A → Mach S A
+register-action mach (record { action = action ; time = time }) =
+  let tick = time-to-tick mach time
+      actions = get-actions (Mach.action-logs mach) tick
+  in if action-in-list mach action actions
+     then mach
+     else (add-action-to-logs 
+            (remove-future-states 
+              (update-cached-tick 
+                (update-genesis-tick mach tick) 
+              tick) 
+            tick) 
+          tick 
+          action)

--- a/UG/SM/remove-future-states.agda
+++ b/UG/SM/remove-future-states.agda
@@ -4,8 +4,9 @@ open import UG.SM.Type
 open import UG.SM.Tick.Type
 open import UG.SM.StateLogs.Type
 open import Data.Nat.Type
+open import Data.Nat.add
 
 -- Removes future states from the state logs
 remove-future-states : ∀ {S A : Set} → Mach S A → Tick → Mach S A 
 remove-future-states mach tick = 
-  record mach { state-logs = remove-range (Mach.state-logs mach) tick (Mach.cached-tick mach) }
+  record mach { state-logs = remove-range (Mach.state-logs mach) (add tick 1) (Mach.cached-tick mach) }

--- a/UG/SM/remove-future-states.agda
+++ b/UG/SM/remove-future-states.agda
@@ -3,10 +3,14 @@ module UG.SM.remove-future-states where
 open import UG.SM.Type
 open import UG.SM.Tick.Type
 open import UG.SM.StateLogs.Type
+open import UG.SM.StateLogs.remove-range
+
 open import Data.Nat.Type
 open import Data.Nat.add
 
--- Removes future states from the state logs
+-- mach : The machine state to update
+-- tick : The current tick, used to determine which states to remove
+-- = Returns an updated Mach with future states removed from state-logs
 remove-future-states : ∀ {S A : Set} → Mach S A → Tick → Mach S A 
 remove-future-states mach tick = 
   record mach { state-logs = remove-range (Mach.state-logs mach) (add tick 1) (Mach.cached-tick mach) }

--- a/UG/SM/remove-future-states.agda
+++ b/UG/SM/remove-future-states.agda
@@ -1,0 +1,11 @@
+module UG.SM.remove-future-states where
+
+open import UG.SM.Type
+open import UG.SM.Tick.Type
+open import UG.SM.StateLogs.Type
+open import Data.Nat.Type
+
+-- Removes future states from the state logs
+remove-future-states : ∀ {S A : Set} → Mach S A → Tick → Mach S A 
+remove-future-states mach tick = 
+  record mach { state-logs = remove-range (Mach.state-logs mach) tick (Mach.cached-tick mach) }

--- a/UG/SM/update-cached-tick.agda
+++ b/UG/SM/update-cached-tick.agda
@@ -6,7 +6,9 @@ open import UG.SM.Tick.Type
 open import Data.Nat.lt
 open import Data.Bool.if
 
--- Updates the cached tick
+-- mach: The machine state to update
+-- new-tick: The new tick value to potentially update the cached tick with
+-- = Returns an updated Mach S A with potentially modified cached-tick
 update-cached-tick : ∀ {S A : Set} → Mach S A → Tick → Mach S A
 update-cached-tick mach new-tick = 
   record mach { cached-tick = if new-tick < Mach.cached-tick mach 

--- a/UG/SM/update-cached-tick.agda
+++ b/UG/SM/update-cached-tick.agda
@@ -1,0 +1,14 @@
+module UG.SM.update-cached-tick where
+
+open import UG.SM.Type
+open import UG.SM.Tick.Type
+
+open import Data.Nat.lt
+open import Data.Bool.if
+
+-- Updates the cached tick
+update-cached-tick : ∀ {S A : Set} → Mach S A → Tick → Mach S A
+update-cached-tick mach new-tick = 
+  record mach { cached-tick = if new-tick < Mach.cached-tick mach 
+                              then new-tick 
+                              else Mach.cached-tick mach }

--- a/UG/SM/update-genesis-tick.agda
+++ b/UG/SM/update-genesis-tick.agda
@@ -1,0 +1,14 @@
+module UG.SM.update-genesis-tick where
+
+open import UG.SM.Type
+open import UG.SM.Tick.Type
+open import Data.Nat.Type
+open import Data.Nat.lt
+open import Data.Bool.if
+
+-- Updates the genesis tick
+update-genesis-tick : ∀ {S A : Set} → Mach S A → Tick → Mach S A
+update-genesis-tick mach new-tick = 
+  record mach { genesis-tick = if new-tick < Mach.genesis-tick mach 
+                               then new-tick 
+                               else Mach.genesis-tick mach }

--- a/UG/SM/update-genesis-tick.agda
+++ b/UG/SM/update-genesis-tick.agda
@@ -5,7 +5,9 @@ open import UG.SM.Tick.Type
 open import Data.Nat.Type
 open import Data.Nat.min
 
--- Updates the genesis tick
+-- mach: The machine state to update
+-- new-tick: The new tick to compare with the current genesis tick
+-- = An updated Mach with the genesis tick set to the minimum of new-tick and the current genesis tick
 update-genesis-tick : ∀ {S A : Set} → Mach S A → Tick → Mach S A
 update-genesis-tick mach new-tick = 
   record mach { genesis-tick = min new-tick (Mach.genesis-tick mach) }

--- a/UG/SM/update-genesis-tick.agda
+++ b/UG/SM/update-genesis-tick.agda
@@ -3,12 +3,9 @@ module UG.SM.update-genesis-tick where
 open import UG.SM.Type
 open import UG.SM.Tick.Type
 open import Data.Nat.Type
-open import Data.Nat.lt
-open import Data.Bool.if
+open import Data.Nat.min
 
 -- Updates the genesis tick
 update-genesis-tick : ∀ {S A : Set} → Mach S A → Tick → Mach S A
 update-genesis-tick mach new-tick = 
-  record mach { genesis-tick = if new-tick < Mach.genesis-tick mach 
-                               then new-tick 
-                               else Mach.genesis-tick mach }
+  record mach { genesis-tick = min new-tick (Mach.genesis-tick mach) }

--- a/UG/SM/update-mach.agda
+++ b/UG/SM/update-mach.agda
@@ -1,0 +1,20 @@
+module UG.SM.update-mach where
+
+open import UG.SM.Type
+open import UG.SM.Tick.Type
+open import UG.SM.StateLogs.Type
+
+open import Data.Nat.max
+open import Data.Map.set
+open import Data.Nat.to-bits
+
+-- mach: The machine to be updated
+-- t: The new tick to update the machine with
+-- s: The new state to be added to the state logs
+-- = Returns an updated Mach with the new tick and state
+update-mach : ∀ {S A : Set} → Mach S A → Tick → S → Mach S A
+update-mach mach t s =
+  record mach
+    { cached-tick = max (Mach.cached-tick mach) t
+    ; state-logs = set (Mach.state-logs mach) (to-bits t) s
+    }


### PR DESCRIPTION
Implements #6

All the helper / book functions implemented here (like gte, lte, max, to-bits) were used to implement the State Machine.

An example of it running is left at UG/SM/Main.agda and can be built and run with:

`agda-compile UG/SM/Main.agda`

`./Main` 

Accepting name suggestions on helpers functions under SM/