### PR TITLE
Add Syntax to Construct Imp Statements using `do`-notation

### DIFF
--- a/Imp/Notation.agda
+++ b/Imp/Notation.agda
@@ -1,0 +1,79 @@
+module Imp.Notation where
+
+open import Imp.Type
+open import Data.Nat.Type
+
+_>>_ : Stmt → Stmt → Stmt
+_>>_ = Then
+
+-- Expressions
+
+infix 100 ↑_
+↑_ : Nat -> Expr
+↑_ = Var
+
+infix 50 _+_ _-_ _*_ _/_ _%_
+infix 40 _&&_ _||_ _==_ _<_
+
+_+_ : Expr → Expr → Expr
+_+_ = Add
+
+_-_ : Expr → Expr → Expr
+_-_ = Sub
+
+_*_ : Expr → Expr → Expr
+_*_ = Mul
+
+_/_ : Expr → Expr → Expr
+_/_ = Div
+
+_%_ : Expr → Expr → Expr
+_%_ = Mod
+
+_&&_ : Expr → Expr → Expr
+_&&_ = And
+
+_||_ : Expr → Expr → Expr
+_||_ = Or
+
+~_ : Expr → Expr
+~_ = Not
+
+_==_ : Expr → Expr → Expr
+_==_ = Eq
+
+_<_ : Expr → Expr → Expr
+_<_ = Lt
+
+infix 30 cond_then_else_
+cond_then_else_ : Expr → Expr → Expr → Expr
+cond_then_else_ = Cond
+
+-- Statements
+
+infix 20 _:l=_ _:s=_ _:g=_
+
+_:l=_ : Nat → Expr → Stmt
+_:l=_ = LSet
+
+_:s=_ : Nat → Expr → Stmt
+_:s=_ = SSet
+
+_:g=_ : Nat → Expr → Stmt
+_:g=_ = GSet
+
+if_then_else_ : Expr → Stmt → Stmt → Stmt
+if_then_else_ = If
+
+while_go_ : Expr -> Stmt -> Stmt
+while_go_ = While
+
+infix 10 return_
+return_ : Expr → Stmt
+return_ = Ret
+
+break : Stmt
+break = Break
+
+continue : Stmt
+continue = Cont

--- a/Imp/Test/Basic.agda
+++ b/Imp/Test/Basic.agda
@@ -1,0 +1,17 @@
+module Imp.Test.Basic where
+
+open import Data.U64.Type
+open import Imp.Type
+open import Imp.Notation
+
+private
+  from-nat = primWord64FromNat
+
+example : Stmt
+example = do
+  0 :l= from-nat 0
+
+  while (↑ 0) < (from-nat 10) go do
+    0 :l= ↑ 0 + (from-nat 1)
+
+  return ↑ 0

--- a/Imp/Type.agda
+++ b/Imp/Type.agda
@@ -7,24 +7,34 @@ open import Data.List.Type
 
 -- Expression type
 data Expr : Set where
-  Var : Nat → Expr
-  Num : U64 → Expr
-  Add : Expr → Expr → Expr
-  Sub : Expr → Expr → Expr
-  Mul : Expr → Expr → Expr
-  Div : Expr → Expr → Expr
-  And : Expr → Expr → Expr
-  Or  : Expr → Expr → Expr
-  Not : Expr → Expr
-  Eq  : Expr → Expr → Expr
-  Lt  : Expr → Expr → Expr
+  Var  : Nat → Expr
+  Num  : U64 → Expr
+  Add  : Expr → Expr → Expr
+  Sub  : Expr → Expr → Expr
+  Mul  : Expr → Expr → Expr
+  Div  : Expr → Expr → Expr
+  Mod  : Expr → Expr → Expr
+  And  : Expr → Expr → Expr
+  Or   : Expr → Expr → Expr
+  Not  : Expr → Expr
+  Eq   : Expr → Expr → Expr
+  Lt   : Expr → Expr → Expr
+  Cond : Expr → Expr → Expr → Expr
 
 -- Statement type
 data Stmt : Set where
-  VSet  : Nat → Expr → Stmt
+  -- Variable Assignments
+  LSet  : Nat → Expr → Stmt -- Local
+  SSet  : Nat → Expr → Stmt -- Shared
+  GSet  : Nat → Expr → Stmt -- Global
+
+  -- Control Flow
   If    : Expr → Stmt → Stmt → Stmt
   While : Expr → Stmt → Stmt
-  Block : List Stmt → Stmt
+  Ret   : Expr → Stmt
+  Cont  : Stmt
+  Break : Stmt
+  Then  : Stmt → Stmt → Stmt
 
 -- Program type
 record Prog : Set where


### PR DESCRIPTION
Allows for creating Imp statements like this.
```agda
example : Stmt
example = do
  0 :l= from-nat 0

  while (↑ 0) < (from-nat 10) go do
    0 :l= ↑ 0 + (from-nat 1)

  return ↑ 0
```