### PR TITLE
Fix setting precedence of operator not defined in file

### DIFF
--- a/Data/Nat/mod.agda
+++ b/Data/Nat/mod.agda
@@ -28,4 +28,4 @@ mod n (Succ m) = mod-aux Zero m n m
 _%_ : Nat → Nat → Nat
 _%_ = mod
 
-infix 7 _mod_
+infix 7 _%_


### PR DESCRIPTION
`Nat/mod.agda` sets `infix` for an identifier that's not defined in this file. Probably a typo.