### PR TITLE
Add example parser for lambda terms

### DIFF
--- a/Data/Parser/Examples/LambdaTerm/Test/y-combinator.agda
+++ b/Data/Parser/Examples/LambdaTerm/Test/y-combinator.agda
@@ -1,0 +1,20 @@
+module Data.Parser.Examples.LambdaTerm.Test.y-combinator where
+
+open import Data.Parser.Error
+open import Data.Parser.Reply
+open import Data.Parser.State
+open import Data.Result.Type
+open import Data.Parser.Type
+open import Data.Parser.Examples.LambdaTerm.Type
+open import Data.Parser.Examples.LambdaTerm.new
+open import Data.Parser.Examples.LambdaTerm.parse
+open import Data.Equal.Type
+
+_ : let parsed = parse (new "λf (λx (f (x x)) λx (f (x x)))")
+    in  parsed == 
+            (Done (MkReply (MkState "" 30)
+            (Lam "f"
+              (App
+                (Lam "x" (App (Var "f") (App (Var "x") (Var "x"))))
+                (Lam "x" (App (Var "f") (App (Var "x") (Var "x"))))))))
+_ = refl

--- a/Data/Parser/Examples/LambdaTerm/Type.agda
+++ b/Data/Parser/Examples/LambdaTerm/Type.agda
@@ -1,0 +1,10 @@
+{-# OPTIONS --no-termination-check #-}
+
+module Data.Parser.Examples.LambdaTerm.Type where
+
+open import Data.String.Type
+
+data Term : Set where
+  Lam : String → Term → Term
+  App : Term → Term → Term
+  Var : String → Term

--- a/Data/Parser/Examples/LambdaTerm/new.agda
+++ b/Data/Parser/Examples/LambdaTerm/new.agda
@@ -1,0 +1,7 @@
+module Data.Parser.Examples.LambdaTerm.new where
+
+open import Data.String.Type
+open import Data.Parser.State
+
+new : String → State
+new str = MkState str 0

--- a/Data/Parser/Examples/LambdaTerm/parse.agda
+++ b/Data/Parser/Examples/LambdaTerm/parse.agda
@@ -1,0 +1,36 @@
+{-# OPTIONS --no-termination-check #-}
+
+module Data.Parser.Examples.LambdaTerm.parse where
+
+open import Data.Parser.Examples.LambdaTerm.Type
+open import Data.String.Type
+open import Data.Maybe.Type
+open import Data.Parser.Type
+open import Data.Parser.State
+open import Data.Parser.skip-trivia
+open import Data.Parser.consume
+open import Data.Parser.peek-one
+open import Data.Parser.parse-name
+open import Data.Parser.bind
+open import Data.Parser.pure
+open import Data.Function.case
+
+parse : Parser Term
+parse = do
+  skip-trivia
+  one ← peek-one
+  case one of λ where
+    (Some 'λ') → do
+      consume "λ"
+      name ← parse-name
+      body ← parse
+      pure (Lam name body)
+    (Some '(') → do
+      consume "("
+      func ← parse
+      argm ← parse
+      consume ")"
+      pure (App func argm)
+    _ → do
+      name ← parse-name
+      pure (Var name)

--- a/Data/Parser/skip-trivia.agda
+++ b/Data/Parser/skip-trivia.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --no-termination-check #-}
+
 module Data.Parser.skip-trivia where
 
 open import Data.Bool.Type

--- a/Data/String/head.agda
+++ b/Data/String/head.agda
@@ -1,14 +1,12 @@
 module Data.String.head where
 
 open import Data.String.Type
+open import Data.String.to-list
 open import Data.Char.Type
 open import Data.Maybe.Type
 open import Data.List.Type
 
-primitive
-  primStringToList : String → List Char
-
 head : String → Maybe Char
-head s with primStringToList s
+head s with to-list s
 ... | []       = None
 ... | (c :: _) = Some c


### PR DESCRIPTION
Adds a simple proof of concept Parser example, the same as in the TSPL crate.