### PR TITLE
[Imp] Add Inline Calls

### DIFF
--- a/Imp/Expr/Type.agda
+++ b/Imp/Expr/Type.agda
@@ -1,15 +1,19 @@
-module Imp.Expr.Type where
+module Imp.Expr.Type ( Stmt : Set ) where
 
-open import Data.String.Type
 open import Data.Nat.Type
 open import Data.Bool.Type
 open import Data.U64.Type
 open import Data.List.Type
+open import Data.String.Type
 
 -- Expression type
 data Expr : Set where
   -- Local variable read
   Var : String → Expr
+
+  -- Grid indices
+  Tid : Expr -- thread id
+  Bid : Expr -- block id
 
   -- Numeric operations
   Num : U64 → Expr
@@ -41,3 +45,6 @@ data Expr : Set where
   GAdd : (var : Nat) → (inc : Expr) → Expr -- Adds `inc` to global `var` returning the old value.
   SExc : (var : Nat) → (new : Expr) → Expr -- Writes `new` to shared `var` returning the old value.
   GExc : (var : Nat) → (new : Expr) → Expr -- Writes `new` to global `var` returning the old value.
+
+  -- A function call, necessary to ensure local variable hygiene
+  Call : Stmt → Expr

--- a/Imp/Expr/show.agda
+++ b/Imp/Expr/show.agda
@@ -1,38 +1,12 @@
 module Imp.Expr.show where
 
-import Data.Nat.show as Nat
-import Data.U64.Type as U64
-open import Imp.Expr.Type
+import Imp.Expr.Type as Expr'
+open import Imp.Stmt.Type
+open import Imp.Show.indented using (show-i-expr)
 open import Data.String.Type
-open import Data.String.append
 
--- Convert an Imp expression to a human-readable string.
+private
+  open module Expr = Expr' Stmt
+
 show : Expr → String
-show (Var v) = v
-show (Num n) = Nat.show (U64.primWord64ToNat n)
-
-show (Add a b) = (show a) ++  " + " ++ (show b)
-show (Sub a b) = (show a) ++  " - " ++ (show b)
-show (Mul a b) = (show a) ++  " * " ++ (show b)
-show (Div a b) = (show a) ++  " / " ++ (show b)
-show (Mod a b) = (show a) ++  " % " ++ (show b)
-show (And a b) = (show a) ++ " && " ++ (show b)
-show (Or  a b) = (show a) ++ " || " ++ (show b)
-show (Not a)   = "~" ++ (show a)
-
-show (Eq  a b) = (show a) ++ " == " ++ (show b)
-show (Neq a b) = (show a) ++ " != " ++ (show b)
-show (Lt  a b) = (show a) ++  " < " ++ (show b)
-show (Le  a b) = (show a) ++ " <= " ++ (show b)
-show (Gt  a b) = (show a) ++  " > " ++ (show b)
-show (Ge  a b) = (show a) ++ " >= " ++ (show b)
-
-show (Cond e a b) = (show e) ++ " ? " ++ (show a) ++ " : " ++ (show b)
-
-show (SGet v) = "atomic_get(shared[" ++ (Nat.show v) ++ "])"
-show (GGet v) = "atomic_get(global[" ++ (Nat.show v) ++ "])"
-
-show (SAdd v e) = "atomic_add(shared[" ++ (Nat.show v) ++ "], " ++ (show e) ++ ")"
-show (GAdd v e) = "atomic_add(global[" ++ (Nat.show v) ++ "], " ++ (show e) ++ ")"
-show (SExc v e) = "atomic_exc(shared[" ++ (Nat.show v) ++ "], " ++ (show e) ++ ")"
-show (GExc v e) = "atomic_exc(shared[" ++ (Nat.show v) ++ "], " ++ (show e) ++ ")"
+show s = show-i-expr 0 s

--- a/Imp/Notation.agda
+++ b/Imp/Notation.agda
@@ -1,14 +1,14 @@
 module Imp.Notation where
 
-open import Data.String.Type
-open import Imp.Expr.Type
+import Imp.Expr.Type as Expr'
 open import Imp.Stmt.Type
 open import Data.Nat.Type
+open import Data.String.Type
 
+private
+  open module Expr = Expr' Stmt
 
--- Monatic then notation for `do` blocks.
-_>>_ = Then
-
+--------------------------------------------------
 -- Expressions
 
 -- Local variable access
@@ -18,23 +18,23 @@ infix 100 ↑_
 -- Numeric operations
 infix 50 _+_ _-_ _*_ _/_ _%_ _&&_ _||_ !_
 
-_+_ = Add
-_-_ = Sub
-_*_ = Mul
-_/_ = Div
-_%_ = Mod
+_+_  = Add
+_-_  = Sub
+_*_  = Mul
+_/_  = Div
+_%_  = Mod
 _&&_ = And
 _||_ = Or
-!_ = Not
+!_   = Not
 
 -- Comparisons
 infix 40 _==_ _!=_ _<_ _<=_ _>_ _>=_
 
 _==_ = Eq
 _!=_ = Eq
-_<_ = Lt
+_<_  = Lt
 _<=_ = Le
-_>_ = Gt
+_>_  = Gt
 _>=_ = Ge
 
 -- Conditionals
@@ -43,7 +43,12 @@ infix 30 cond_then_else_
 cond_then_else_ : Expr → Expr → Expr → Expr
 cond_then_else_ = Cond
 
+--------------------------------------------------
 -- Statements
+
+-- Declarations
+
+local_ = Locals
 
 -- Assignments
 infix 20 _:=_ _s=_ _g=_
@@ -52,39 +57,31 @@ _:=_ = LSet
 _s=_ = SSet
 _g=_ = GSet
 
--- Convenience Assignments
+-- Convenience Local Assignments
 infix 20 _+=_ _-=_
 
 _+=_ : String → Expr → Stmt
-_+=_ v x = LSet v (Add (Var v) x)
+_+=_ v e = LSet v (Add (Var v) e)
 
 _-=_ : String → Expr → Stmt
-_-=_ v x = LSet v (Sub (Var v) x)
+_-=_ v e = LSet v (Sub (Var v) e)
 
 -- Control flow
 infix 5 if_then_ elif_then_ else_ while_go_
 
-if_then_ : Expr → Stmt → Stmt
-if_then_ = If
-
-elif_then_ : Expr → Stmt → Stmt
+if_then_   = If
 elif_then_ = ElseIf
+else_      = Else
+while_go_  = While
 
-else_ : Stmt → Stmt
-else_ = Else
+-- Monadic then notation for `do` blocks.
+_>>_ = Then
 
-while_go_ : Expr -> Stmt -> Stmt
-while_go_ = While
-
+--------------------------------------------------
 -- Exceptional control flow
 
 infix 15 return_
 
-return_ : Expr → Stmt
-return_ = Ret
-
-break : Stmt
-break = Break
-
-continue : Stmt
+return_  = Ret
+break    = Break
 continue = Cont

--- a/Imp/Show/indented.agda
+++ b/Imp/Show/indented.agda
@@ -1,0 +1,101 @@
+-- Provides functions to display Imp expressions and statements at
+-- a specific indentation level. These are used for the Show implementations
+-- of each of the types.
+
+module Imp.Show.indented where
+
+import Imp.Expr.Type as Expr'
+import Data.Nat.show as Nat
+import Data.U64.Type as U64
+open import Imp.Stmt.Type
+open import Data.Nat.Type
+open import Data.Nat.add
+open import Data.String.Type
+open import Data.String.append
+open import Data.String.join
+
+private
+  open module Expr = Expr' Stmt
+
+  -- indent by two spaces
+  indent : Nat → String
+  indent Zero     = ""
+  indent (Succ n) = "  " ++ (indent n)
+
+interleaved mutual
+  show-i-expr : Nat → Expr → String
+  show-i-stmt : Nat → Stmt → String
+
+  show-i-expr _ (Var v) = v
+  show-i-expr _ (Num n) = Nat.show (U64.primWord64ToNat n)
+
+  show-i-expr _ Tid = "thread_id()"
+  show-i-expr _ Bid = "block_id()"
+
+  show-i-expr i (Add a b) = (show-i-expr i a) ++  " + " ++ (show-i-expr i b)
+  show-i-expr i (Sub a b) = (show-i-expr i a) ++  " - " ++ (show-i-expr i b)
+  show-i-expr i (Mul a b) = (show-i-expr i a) ++  " * " ++ (show-i-expr i b)
+  show-i-expr i (Div a b) = (show-i-expr i a) ++  " / " ++ (show-i-expr i b)
+  show-i-expr i (Mod a b) = (show-i-expr i a) ++  " % " ++ (show-i-expr i b)
+  show-i-expr i (And a b) = (show-i-expr i a) ++ " && " ++ (show-i-expr i b)
+  show-i-expr i (Or  a b) = (show-i-expr i a) ++ " || " ++ (show-i-expr i b)
+  show-i-expr i (Not a)   = "~" ++ (show-i-expr i a)
+
+  show-i-expr i (Eq  a b) = (show-i-expr i a) ++ " == " ++ (show-i-expr i b)
+  show-i-expr i (Neq a b) = (show-i-expr i a) ++ " != " ++ (show-i-expr i b)
+  show-i-expr i (Lt  a b) = (show-i-expr i a) ++  " < " ++ (show-i-expr i b)
+  show-i-expr i (Le  a b) = (show-i-expr i a) ++ " <= " ++ (show-i-expr i b)
+  show-i-expr i (Gt  a b) = (show-i-expr i a) ++  " > " ++ (show-i-expr i b)
+  show-i-expr i (Ge  a b) = (show-i-expr i a) ++ " >= " ++ (show-i-expr i b)
+
+  show-i-expr i (Cond e a b) = (show-i-expr i e) ++ " ? " ++ (show-i-expr i a) ++ " : " ++ (show-i-expr i b)
+
+  show-i-expr _ (SGet v) = "atomic_get(shared[" ++ (Nat.show v) ++ "])"
+  show-i-expr _ (GGet v) = "atomic_get(global[" ++ (Nat.show v) ++ "])"
+
+  show-i-expr i (SAdd v e) = "atomic_add(shared[" ++ (Nat.show v) ++ "], " ++ (show-i-expr i e) ++ ")"
+  show-i-expr i (GAdd v e) = "atomic_add(global[" ++ (Nat.show v) ++ "], " ++ (show-i-expr i e) ++ ")"
+  show-i-expr i (SExc v e) = "atomic_exc(shared[" ++ (Nat.show v) ++ "], " ++ (show-i-expr i e) ++ ")"
+  show-i-expr i (GExc v e) = "atomic_exc(shared[" ++ (Nat.show v) ++ "], " ++ (show-i-expr i e) ++ ")"
+
+  show-i-expr i (Call s) =
+    "({\n" ++
+      (show-i-stmt (i + 1) s) ++
+    (indent i) ++ "\n})"
+
+  show-i-stmt i (Locals vs) = (indent i) ++ "local " ++ (join ", " vs)
+
+  show-i-stmt i (LSet v e) = (indent i) ++ v ++ " = " ++ (show-i-expr i e)
+
+  show-i-stmt i (SSet n e) = (indent i) ++ "atomic_set(shared[" ++ (Nat.show n) ++ "], " ++ (show-i-expr i e) ++ ")"
+  show-i-stmt i (GSet n e) = (indent i) ++ "atomic_set(global[" ++ (Nat.show n) ++ "], " ++ (show-i-expr i e) ++ ")"
+
+  show-i-stmt i (If e a) =
+    (indent i) ++ "if (" ++ (show-i-expr i e) ++ ") {\n" ++
+      (show-i-stmt (i + 1) a) ++ "\n" ++
+    (indent i) ++ "}"
+
+  show-i-stmt i (ElseIf e a) =
+    (indent i) ++ "else if (" ++ (show-i-expr i e) ++ " {\n" ++
+      (show-i-stmt (i + 1) a) ++ "\n" ++
+    (indent i) ++ "}"
+
+  show-i-stmt i (Else a) =
+    (indent i) ++ "else {\n" ++
+      (show-i-stmt (i + 1) a) ++ "\n" ++
+    (indent i) ++ "}"
+
+  show-i-stmt i (While e b) =
+    (indent i) ++ "while (" ++ (show-i-expr i e) ++ ") {\n" ++
+      (show-i-stmt (i + 1) b) ++ "\n" ++
+    (indent i) ++ "}"
+
+  show-i-stmt i (Ret e) =
+    (indent i) ++ "return " ++ (show-i-expr i e)
+
+  show-i-stmt i (Cont)  = (indent i) ++ "continue"
+  show-i-stmt i (Break) = (indent i) ++ "break"
+
+  show-i-stmt i (Ignore e) = (indent i) ++ (show-i-expr i e)
+
+  show-i-stmt i (Then a b) = (show-i-stmt i a) ++ "\n" ++ (show-i-stmt i b)

--- a/Imp/Stmt/Type.agda
+++ b/Imp/Stmt/Type.agda
@@ -1,14 +1,23 @@
 module Imp.Stmt.Type where
 
-open import Imp.Expr.Type
+import Imp.Expr.Type as Expr'
 open import Data.String.Type
 open import Data.Nat.Type
 open import Data.Bool.Type
 open import Data.U64.Type
 open import Data.List.Type
 
+data Stmt : Set
+
+private
+  open module Expr = Expr' Stmt
+
 -- Statement type
-data Stmt : Set where
+-- TODO(enricozb): need synchronization primitives (block & global)
+data Stmt where
+  -- Declares local variables
+  Locals : List String → Stmt
+
   -- Variable Assignments
   LSet : String → Expr → Stmt -- set local variable
 
@@ -24,7 +33,9 @@ data Stmt : Set where
   Ret    : Expr → Stmt
   Cont   : Stmt
   Break  : Stmt
-  Then   : Stmt → Stmt → Stmt
+
+  -- Monadic then (>>)
+  Then : Stmt → Stmt → Stmt
 
   -- Executes an expression and drops the value
   Ignore : Expr → Stmt

--- a/Imp/Stmt/show.agda
+++ b/Imp/Stmt/show.agda
@@ -1,57 +1,8 @@
 module Imp.Stmt.show where
 
-import Data.Nat.show as Nat
-import Imp.Expr.show as Expr
-
 open import Imp.Stmt.Type
-open import Data.Nat.Type
-open import Data.Nat.add
+open import Imp.Show.indented using (show-i-stmt)
 open import Data.String.Type
-open import Data.String.append
 
-private
-  -- indent by two spaces
-  indent : Nat → String
-  indent Zero     = ""
-  indent (Succ n) = "  " ++ (indent n)
-
--- Convert an Imp statement to a human-readable string.
 show : Stmt → String
-show s = show-indented 0 s where
-
-  show-indented : Nat → Stmt → String
-
-  show-indented i (LSet v e) = (indent i) ++ v ++ " = " ++ (Expr.show e)
-
-  show-indented i (SSet n e) = (indent i) ++ "atomic_set(shared[" ++ (Nat.show n) ++ "], " ++ (Expr.show e) ++ ")"
-  show-indented i (GSet n e) = (indent i) ++ "atomic_set(global[" ++ (Nat.show n) ++ "], " ++ (Expr.show e) ++ ")"
-
-  show-indented i (If e a) =
-    (indent i) ++ "if (" ++ (Expr.show e) ++ ") {\n" ++
-      (show-indented (i + 1) a) ++ "\n" ++
-    (indent i) ++ "}"
-
-  show-indented i (ElseIf e a) =
-    (indent i) ++ "else if (" ++ (Expr.show e) ++ " {\n" ++
-      (show-indented (i + 1) a) ++ "\n" ++
-    (indent i) ++ "}"
-
-  show-indented i (Else a) =
-    (indent i) ++ "else {\n" ++
-      (show-indented (i + 1) a) ++ "\n" ++
-    (indent i) ++ "}"
-
-  show-indented i (While e b) =
-    (indent i) ++ "while (" ++ (Expr.show e) ++ ") {\n" ++
-      (show-indented (i + 1) b) ++ "\n" ++
-    (indent i) ++ "}"
-
-  show-indented i (Ret e) =
-    (indent i) ++ "return " ++ (Expr.show e)
-
-  show-indented i (Cont)  = (indent i) ++ "continue"
-  show-indented i (Break) = (indent i) ++ "break"
-
-  show-indented i (Ignore e) = (indent i) ++ (Expr.show e)
-
-  show-indented i (Then a b) = (show-indented i a) ++ "\n" ++ (show-indented i b)
+show s = show-i-stmt 0 s

--- a/Imp/Test/show.agda
+++ b/Imp/Test/show.agda
@@ -6,6 +6,7 @@ open import Imp.Expr.Type
 open import Imp.Stmt.Type
 open import Imp.Notation
 open import Imp.Stmt.show as Stmt
+open import Data.Equal.Type
 
 private
   from-nat : Nat → Expr
@@ -40,8 +41,6 @@ while (a < 10) {
     return i
   }
 }"
-
-open import Data.Equal.Type renaming (_==_ to _===_)
 
 test-example : (Stmt.show example) === expected-string
 test-example = refl


### PR DESCRIPTION
Adds a `Call` expression that consumes a statement (which should be a function) and produces a expression. This complicates the stringifier as `Expr` and `Stmt` are mutually recursive and the stringifier has indent levels for readability.

The idea behind how a call expression will be stringified to C will be through GNU C [statement expressions](https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html) and [local labels](https://www.gnu.org/software/c-intro-and-ref/manual/html_node/Local-Labels.html) (supported by gcc clang).

For example, the following agda code (`example`)
```agda
fib : Expr → Stmt
fib n = do
  local ("a" :: "b" :: "t" :: [])

  "a" := from-nat 0
  "b" := from-nat 1
  "n" := n

  while ↑"n" > from-nat 0 go do
    "t" := ↑"b"
    "b" += ↑"a"
    "a" := ↑"t"
    "n" -= from-nat 1

  return ↑"a"

example : Stmt
example = do
  local ("fib1" :: [])

  "fib1" := Call (fib (from-nat 1))
```
will be stringified to C as
```c
u64 fib1, fib2;

fib1 = ({
  __local__ RETURN;
  u64 __ret__;

  u64 a, b, t;
  u64 n = 1;

  a = 0;
  b = 1;

  while (n > 0) {
    t = b;
    b = a + b;
    a = t;

    n = n - 1;
  }
  
  __ret__ = a;
  goto RETURN;

  RETURN: __ret__;
});
```
