### PR TITLE
Implement AVL trees

### DIFF
--- a/Data/AVLTree/Balance/Type.agda
+++ b/Data/AVLTree/Balance/Type.agda
@@ -1,5 +1,9 @@
 module Data.AVLTree.Balance.Type where
 
+-- Represents the balance factor of an AVL tree node.
+-- - -one: Left subtree is taller by 1.
+-- - zero: Left and right subtrees have the same height.
+-- - +one: Right subtree is taller by 1.
 data Balance : Set where
   -one : Balance
   zero : Balance

--- a/Data/AVLTree/Balance/Type.agda
+++ b/Data/AVLTree/Balance/Type.agda
@@ -1,0 +1,6 @@
+module Data.AVLTree.Balance.Type where
+
+data Balance : Set where
+  -one : Balance
+  zero : Balance
+  +one : Balance

--- a/Data/AVLTree/Balance/eq.agda
+++ b/Data/AVLTree/Balance/eq.agda
@@ -1,0 +1,15 @@
+module Data.AVLTree.Balance.eq where
+
+open import Data.AVLTree.Balance.Type
+open import Data.Trait.Eq public
+open import Data.Trait.Eq.default-eq
+open import Data.Bool.Type
+
+instance
+  EqBalance : Eq Balance
+  EqBalance = default-eq eq-bal where
+    eq-bal : Balance → Balance → Bool
+    eq-bal -one -one = True
+    eq-bal zero zero = True
+    eq-bal +one +one = True
+    eq-bal _    _    = False

--- a/Data/AVLTree/Balance/eq.agda
+++ b/Data/AVLTree/Balance/eq.agda
@@ -7,9 +7,8 @@ open import Data.Bool.Type
 
 instance
   EqBalance : Eq Balance
-  EqBalance = default-eq eq-bal where
-    eq-bal : Balance → Balance → Bool
-    eq-bal -one -one = True
-    eq-bal zero zero = True
-    eq-bal +one +one = True
-    eq-bal _    _    = False
+  EqBalance = default-eq λ where
+    -one -one → True
+    zero zero → True
+    +one +one → True
+    _    _    → False

--- a/Data/AVLTree/Balance/rotate-left.agda
+++ b/Data/AVLTree/Balance/rotate-left.agda
@@ -26,36 +26,36 @@ rotate-left
   , False
 
 rotate-left
-     (Node v₁ +one
+   (Node v₁ +one
+      left
+      (Node v₂ zero
+        child-left
+        child-right))
+  = Node v₂ -one
+      (Node v₁ +one
         left
-        (Node v₂ zero
-          child-left
-          child-right))
-    = Node v₂ -one
-        (Node v₁ +one
-          left
-          child-left)
-        child-right
-    , True
+        child-left)
+      child-right
+  , True
 
 rotate-left
-     (Node v₁ +one
+   (Node v₁ +one
+      left
+      (Node v₂ -one
+        (Node v₃ balance
+          child-child-left
+          child-child-right)
+        child-right))
+  = let b₁ = if balance == +one then -one else zero
+        b₂ = if balance == -one then +one else zero in
+    Node v₃ zero
+      (Node v₁ b₁
         left
-        (Node v₂ -one
-          (Node v₃ balance
-            child-child-left
-            child-child-right)
-          child-right))
-    = let b₁ = if balance == +one then -one else zero
-          b₂ = if balance == -one then +one else zero in
-      Node v₃ zero
-        (Node v₁ b₁
-          left
-          child-child-left)
-        (Node v₂ b₂
-          child-child-right
-          child-right)
-      , False
+        child-child-left)
+      (Node v₂ b₂
+        child-child-right
+        child-right)
+    , False
 
 -- Invalid call to `rotate-left`
 rotate-left tree = tree , False

--- a/Data/AVLTree/Balance/rotate-left.agda
+++ b/Data/AVLTree/Balance/rotate-left.agda
@@ -1,0 +1,57 @@
+module Data.AVLTree.Balance.rotate-left where
+
+open import Data.AVLTree.Type
+open import Data.AVLTree.empty
+open import Data.AVLTree.Balance.Type
+open import Data.AVLTree.Balance.eq
+open import Data.Pair.Type
+open import Data.Bool.Type
+open import Data.Bool.if
+
+-- fixes imbalance of 2, returns True if height of root stayed the same
+rotate-left : ∀ {A : Set} → AVLTree A → Pair (AVLTree A) Bool
+rotate-left tree with tree
+... | Node v₁ +one
+        left
+        (Node v₂ +one
+          child-left
+          child-right)
+    = Node v₂ zero
+        (Node v₁ zero
+          left
+          child-left)
+        child-right
+    , False
+
+... | Node v₁ +one
+        left
+        (Node v₂ zero
+          child-left
+          child-right)
+    = Node v₂ -one
+        (Node v₁ +one
+          left
+          child-left)
+        child-right
+    , True
+
+... | Node v₁ +one
+        left
+        (Node v₂ -one
+          (Node v₃ balance
+            child-child-left
+            child-child-right)
+          child-right)
+    = let b₁ = if balance == +one then -one else zero
+          b₂ = if balance == -one then +one else zero in
+      Node v₃ zero
+        (Node v₁ b₁
+          left
+          child-child-left)
+        (Node v₂ b₂
+          child-child-right
+          child-right)
+      , False
+
+-- Invalid call to `rotate-left`
+... | _ = tree , False

--- a/Data/AVLTree/Balance/rotate-left.agda
+++ b/Data/AVLTree/Balance/rotate-left.agda
@@ -12,24 +12,25 @@ open import Data.Bool.if
 -- - tree: The AVL tree to rotate.
 -- = A pair containing the rotated AVL tree and a boolean indicating if the height of the root stayed the same.
 rotate-left : ∀ {A : Set} → AVLTree A → Pair (AVLTree A) Bool
-rotate-left tree with tree
-... | Node v₁ +one
+rotate-left
+   (Node v₁ +one
+      left
+      (Node v₂ +one
+        child-left
+        child-right))
+  = Node v₂ zero
+      (Node v₁ zero
         left
-        (Node v₂ +one
-          child-left
-          child-right)
-    = Node v₂ zero
-        (Node v₁ zero
-          left
-          child-left)
-        child-right
-    , False
+        child-left)
+      child-right
+  , False
 
-... | Node v₁ +one
+rotate-left
+     (Node v₁ +one
         left
         (Node v₂ zero
           child-left
-          child-right)
+          child-right))
     = Node v₂ -one
         (Node v₁ +one
           left
@@ -37,13 +38,14 @@ rotate-left tree with tree
         child-right
     , True
 
-... | Node v₁ +one
+rotate-left
+     (Node v₁ +one
         left
         (Node v₂ -one
           (Node v₃ balance
             child-child-left
             child-child-right)
-          child-right)
+          child-right))
     = let b₁ = if balance == +one then -one else zero
           b₂ = if balance == -one then +one else zero in
       Node v₃ zero
@@ -56,4 +58,4 @@ rotate-left tree with tree
       , False
 
 -- Invalid call to `rotate-left`
-... | _ = tree , False
+rotate-left tree = tree , False

--- a/Data/AVLTree/Balance/rotate-left.agda
+++ b/Data/AVLTree/Balance/rotate-left.agda
@@ -8,7 +8,9 @@ open import Data.Pair.Type
 open import Data.Bool.Type
 open import Data.Bool.if
 
--- fixes imbalance of 2, returns True if height of root stayed the same
+-- Performs a left rotation on an AVL tree to fix an imbalance of +2.
+-- - tree: The AVL tree to rotate.
+-- = A pair containing the rotated AVL tree and a boolean indicating if the height of the root stayed the same.
 rotate-left : ∀ {A : Set} → AVLTree A → Pair (AVLTree A) Bool
 rotate-left tree with tree
 ... | Node v₁ +one

--- a/Data/AVLTree/Balance/rotate-right.agda
+++ b/Data/AVLTree/Balance/rotate-right.agda
@@ -12,12 +12,12 @@ open import Data.Bool.if
 -- - tree: The AVL tree to rotate.
 -- = A pair containing the rotated AVL tree and a boolean indicating if the height of the root stayed the same.
 rotate-right : ∀ {A : Set} → AVLTree A → Pair (AVLTree A) Bool
-rotate-right tree with tree
-... | Node v₁ -one
+rotate-right
+     (Node v₁ -one
         (Node v₂ -one
           child-left
           child-right)
-        right
+        right)
     = Node v₂ zero
         child-left 
         (Node v₁ zero
@@ -25,11 +25,12 @@ rotate-right tree with tree
           right)
       , False
 
-... | Node v₁ -one
+rotate-right
+     (Node v₁ -one
         (Node v₂ zero
           child-left
           child-right)
-        right
+        right)
     = Node v₂ +one
         child-left
         (Node v₁ -one
@@ -37,12 +38,13 @@ rotate-right tree with tree
           right)
       , True
 
-... | Node v₁ -one
+rotate-right
+     (Node v₁ -one
         (Node v₂ +one child-left
           (Node v₃ balance
             child-child-left
             child-child-right))
-        right
+        right)
     = let b₁ = if balance == +one then -one else zero
           b₂ = if balance == -one then +one else zero in
       Node v₃ zero
@@ -55,4 +57,4 @@ rotate-right tree with tree
       , False
 
 -- Invalid call to `rotate-right`
-... | _ = tree , False
+rotate-right tree = tree , False

--- a/Data/AVLTree/Balance/rotate-right.agda
+++ b/Data/AVLTree/Balance/rotate-right.agda
@@ -13,48 +13,48 @@ open import Data.Bool.if
 -- = A pair containing the rotated AVL tree and a boolean indicating if the height of the root stayed the same.
 rotate-right : ∀ {A : Set} → AVLTree A → Pair (AVLTree A) Bool
 rotate-right
-     (Node v₁ -one
-        (Node v₂ -one
-          child-left
-          child-right)
-        right)
-    = Node v₂ zero
-        child-left 
-        (Node v₁ zero
-          child-right
-          right)
-      , False
-
-rotate-right
-     (Node v₁ -one
-        (Node v₂ zero
-          child-left
-          child-right)
-        right)
-    = Node v₂ +one
+   (Node v₁ -one
+      (Node v₂ -one
         child-left
-        (Node v₁ -one
-          child-right
-          right)
-      , True
+        child-right)
+      right)
+  = Node v₂ zero
+      child-left 
+      (Node v₁ zero
+        child-right
+        right)
+    , False
 
 rotate-right
-     (Node v₁ -one
-        (Node v₂ +one child-left
-          (Node v₃ balance
-            child-child-left
-            child-child-right))
+   (Node v₁ -one
+      (Node v₂ zero
+        child-left
+        child-right)
+      right)
+  = Node v₂ +one
+      child-left
+      (Node v₁ -one
+        child-right
         right)
-    = let b₁ = if balance == +one then -one else zero
-          b₂ = if balance == -one then +one else zero in
-      Node v₃ zero
-        (Node v₂ b₁
-          child-left
-          child-child-left)
-        (Node v₁ b₂
-          child-child-right
-          right)
-      , False
+    , True
+
+rotate-right
+   (Node v₁ -one
+      (Node v₂ +one child-left
+        (Node v₃ balance
+          child-child-left
+          child-child-right))
+      right)
+  = let b₁ = if balance == +one then -one else zero
+        b₂ = if balance == -one then +one else zero in
+    Node v₃ zero
+      (Node v₂ b₁
+        child-left
+        child-child-left)
+      (Node v₁ b₂
+        child-child-right
+        right)
+    , False
 
 -- Invalid call to `rotate-right`
 rotate-right tree = tree , False

--- a/Data/AVLTree/Balance/rotate-right.agda
+++ b/Data/AVLTree/Balance/rotate-right.agda
@@ -1,0 +1,56 @@
+module Data.AVLTree.Balance.rotate-right where
+
+open import Data.AVLTree.Type
+open import Data.AVLTree.empty
+open import Data.AVLTree.Balance.Type
+open import Data.AVLTree.Balance.eq
+open import Data.Pair.Type
+open import Data.Bool.Type
+open import Data.Bool.if
+
+-- fixes imbalance of -2, returns True if height of root stayed the same
+rotate-right : ∀ {A : Set} → AVLTree A → Pair (AVLTree A) Bool
+rotate-right tree with tree
+... | Node v₁ -one
+        (Node v₂ -one
+          child-left
+          child-right)
+        right
+    = Node v₂ zero
+        child-left 
+        (Node v₁ zero
+          child-right
+          right)
+      , False
+
+... | Node v₁ -one
+        (Node v₂ zero
+          child-left
+          child-right)
+        right
+    = Node v₂ +one
+        child-left
+        (Node v₁ -one
+          child-right
+          right)
+      , True
+
+... | Node v₁ +one
+        (Node v₂ +one child-left
+          (Node v₃ balance
+            child-child-left
+            child-child-right))
+        right
+    = let b₁ = if balance == +one then -one else zero
+          b₂ = if balance == -one then +one else zero in
+      Node v₃ zero
+        (Node v₂ b₁
+          child-left
+          child-child-left)
+        (Node v₁ b₂
+          child-child-right
+          right)
+      , False
+
+-- Invalid call to `rotate-right`
+... | _ = tree , False

--- a/Data/AVLTree/Balance/rotate-right.agda
+++ b/Data/AVLTree/Balance/rotate-right.agda
@@ -37,7 +37,7 @@ rotate-right tree with tree
           right)
       , True
 
-... | Node v₁ +one
+... | Node v₁ -one
         (Node v₂ +one child-left
           (Node v₃ balance
             child-child-left

--- a/Data/AVLTree/Balance/rotate-right.agda
+++ b/Data/AVLTree/Balance/rotate-right.agda
@@ -8,7 +8,9 @@ open import Data.Pair.Type
 open import Data.Bool.Type
 open import Data.Bool.if
 
--- fixes imbalance of -2, returns True if height of root stayed the same
+-- Performs a right rotation on an AVL tree to fix an imbalance of -2.
+-- - tree: The AVL tree to rotate.
+-- = A pair containing the rotated AVL tree and a boolean indicating if the height of the root stayed the same.
 rotate-right : ∀ {A : Set} → AVLTree A → Pair (AVLTree A) Bool
 rotate-right tree with tree
 ... | Node v₁ -one

--- a/Data/AVLTree/Test/delete-maximum.agda
+++ b/Data/AVLTree/Test/delete-maximum.agda
@@ -1,0 +1,63 @@
+module Data.AVLTree.Test.delete-maximum where
+
+open import Data.AVLTree.Type
+open import Data.AVLTree.insert
+open import Data.AVLTree.delete-maximum
+open import Data.AVLTree.to-list
+open import Data.AVLTree.empty
+open import Data.AVLTree.Balance.Type
+open import Data.AVLTree.Test.is-balanced
+open import Data.List.Type
+open import Data.List.eq
+open import Data.Nat.Type
+open import Data.Nat.eq
+open import Data.Nat.ord
+open import Data.Equal.Type
+open import Data.Pair.Type
+open import Data.Maybe.Type
+open import Data.Bool.Type
+open import Data.Bool.or
+open import Data.Bool.and
+open import Data.Trait.Ord
+open import Data.Nat.lt
+
+-- Helper function to create a test tree
+create-test-tree : AVLTree Nat
+create-test-tree =
+  10 ::> 2 ::> 8 ::> 6 ::> 4 ::> 9 ::> 1 ::> 7 ::> 3 ::> 5 ::> empty
+
+-- Test 1: Deleting maximum from an empty tree
+test-empty : ((empty , None) , False) === delete-maximum {Nat} empty
+test-empty = refl
+
+-- Test 2: Deleting maximum from a single-node tree
+test-single-node : ((empty , Some 5) , True) === delete-maximum (Node 5 zero empty empty)
+test-single-node = refl
+
+-- Test 3: Deleting maximum from a larger tree
+test-larger-tree : to-list (Pair.fst (Pair.fst (delete-maximum create-test-tree))) === (1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: 9 :: [])
+test-larger-tree = refl
+
+-- Test 4: Checking the maximum value returned
+test-max-value : Some 10 === Pair.snd (Pair.fst (delete-maximum create-test-tree))
+test-max-value = refl
+
+-- Test 5: Deleting maximum multiple times
+test-multiple-delete : 
+  let tree₁ = Pair.fst (Pair.fst (delete-maximum create-test-tree))
+      tree₂ = Pair.fst (Pair.fst (delete-maximum tree₁))
+      tree₃ = Pair.fst (Pair.fst (delete-maximum tree₂))
+  in to-list tree₃ === (1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: [])
+test-multiple-delete = refl
+
+-- Test 6: Checking if the tree remains balanced after deleting maximum
+test-balanced-after-delete : True === is-balanced? (Pair.fst (Pair.fst (delete-maximum create-test-tree)))
+test-balanced-after-delete = refl
+
+-- Test 7: Checking if the tree remains balanced after multiple deletions
+test-balanced-after-multiple-deletes :
+  let tree₁ = Pair.fst (Pair.fst (delete-maximum create-test-tree))
+      tree₂ = Pair.fst (Pair.fst (delete-maximum tree₁))
+      tree₃ = Pair.fst (Pair.fst (delete-maximum tree₂))
+  in True === (is-balanced? tree₁ && is-balanced? tree₂ && is-balanced? tree₃)
+test-balanced-after-multiple-deletes = refl

--- a/Data/AVLTree/Test/delete.agda
+++ b/Data/AVLTree/Test/delete.agda
@@ -1,0 +1,78 @@
+module Data.AVLTree.Test.delete where
+
+open import Data.AVLTree.Type
+open import Data.AVLTree.delete
+open import Data.AVLTree.insert
+open import Data.AVLTree.empty
+open import Data.AVLTree.to-list
+open import Data.AVLTree.Test.is-balanced
+open import Data.Equal.Type
+open import Data.Bool.Type
+open import Data.Bool.and
+open import Data.Nat.Type
+open import Data.Nat.eq
+open import Data.Nat.ord
+open import Data.List.Type
+open import Data.List.eq
+
+-- Test 1: Deleting from an empty tree
+test-delete-empty : delete 5 empty === empty
+test-delete-empty = refl
+
+-- Test 2: Deleting a non-existent element
+test-delete-non-existent : delete 5 (insert 3 empty) === insert 3 empty
+test-delete-non-existent = refl
+
+-- Test 3: Deleting the root of a single-element tree
+test-delete-root-single : delete 3 (insert 3 empty) === empty
+test-delete-root-single = refl
+
+-- Test 4: Deleting from a balanced tree
+test-delete-balanced : 
+  let tree = insert 2 (insert 1 (insert 3 empty))
+      result = delete 2 tree
+  in (to-list result == to-list (insert 3 (insert 1 empty))) && is-balanced? result === True
+test-delete-balanced = refl
+
+-- Test 5: Deleting causing a left rotation
+test-delete-left-rotation :
+  let tree = insert 4 (insert 3 (insert 2 (insert 1 empty)))
+      result = delete 1 tree
+  in is-balanced? result === True
+test-delete-left-rotation = refl
+
+-- Test 6: Deleting causing a right rotation
+test-delete-right-rotation :
+  let tree = insert 1 (insert 2 (insert 3 (insert 4 empty)))
+      result = delete 4 tree
+  in is-balanced? result === True
+test-delete-right-rotation = refl
+
+-- Test 7: Deleting from a larger tree
+test-delete-larger-tree :
+  let tree = insert 5 (insert 3 (insert 7 (insert 2 (insert 4 (insert 6 (insert 8 empty))))))
+      result = delete 3 tree
+  in is-balanced? result && (to-list result == 2 :: 4 :: 5 :: 6 :: 7 :: 8 :: []) === True
+test-delete-larger-tree = refl
+
+-- Test 8: Multiple deletions
+test-multiple-deletions :
+  let tree = insert 5 (insert 3 (insert 7 (insert 2 (insert 4 (insert 6 (insert 8 empty))))))
+      result = delete 4 (delete 7 (delete 2 tree))
+  in is-balanced? result && (to-list result == 3 :: 5 :: 6 :: 8 :: []) === True
+test-multiple-deletions = refl
+
+-- Test 9: Deleting all elements
+test-delete-all :
+  let tree = insert 3 (insert 2 (insert 1 empty))
+      result = delete 2 (delete 3 (delete 1 tree))
+  in result === empty
+test-delete-all = refl
+
+-- Test 10: Deleting and re-inserting
+test-delete-reinsert :
+  let tree = insert 3 (insert 2 (insert 1 empty))
+      intermediate = delete 2 tree
+      result = insert 2 intermediate
+  in (to-list result == to-list tree) && is-balanced? result === True
+test-delete-reinsert = refl

--- a/Data/AVLTree/Test/has-key.agda
+++ b/Data/AVLTree/Test/has-key.agda
@@ -1,0 +1,59 @@
+module Data.AVLTree.Test.has-key where
+
+open import Data.AVLTree.Type
+open import Data.AVLTree.empty
+open import Data.AVLTree.insert
+open import Data.AVLTree.has-key
+open import Data.Equal.Type
+open import Data.Bool.Type
+open import Data.Nat.Type
+open import Data.Nat.ord
+open import Data.Trait.Ord
+
+-- Sample AVL tree for testing
+sample-tree : AVLTree Nat
+sample-tree = 5 ::> 3 ::> 7 ::> 1 ::> 4 ::> 6 ::> 8 ::> empty
+
+-- Test 1: Empty tree
+test-empty : has-key 5 empty === False
+test-empty = refl
+
+-- Test 2: Key present in root
+test-root : has-key 5 sample-tree === True
+test-root = refl
+
+-- Test 3: Key present in left subtree
+test-left : has-key 3 sample-tree === True
+test-left = refl
+
+-- Test 4: Key present in right subtree
+test-right : has-key 7 sample-tree === True
+test-right = refl
+
+-- Test 5: Key present in leftmost leaf
+test-leftmost : has-key 1 sample-tree === True
+test-leftmost = refl
+
+-- Test 6: Key present in rightmost leaf
+test-rightmost : has-key 8 sample-tree === True
+test-rightmost = refl
+
+-- Test 7: Key not present (less than all keys)
+test-not-present-less : has-key 0 sample-tree === False
+test-not-present-less = refl
+
+-- Test 8: Key not present (greater than all keys)
+test-not-present-greater : has-key 9 sample-tree === False
+test-not-present-greater = refl
+
+-- Test 9: Key not present (between existing keys)
+test-not-present-between : has-key 2 sample-tree === False
+test-not-present-between = refl
+
+-- Test 10: Single-element tree (key present)
+test-single-present : has-key 1 (1 ::> empty) === True
+test-single-present = refl
+
+-- Test 11: Single-element tree (key not present)
+test-single-not-present : has-key 2 (1 ::> empty) === False
+test-single-not-present = refl

--- a/Data/AVLTree/Test/insert.agda
+++ b/Data/AVLTree/Test/insert.agda
@@ -1,0 +1,46 @@
+module Data.AVLTree.Test.insert where
+
+open import Data.AVLTree.Type
+open import Data.AVLTree.insert
+open import Data.AVLTree.empty
+open import Data.AVLTree.from-list
+open import Data.AVLTree.Balance.Type
+open import Data.AVLTree.Test.is-balanced
+open import Data.Equal.Type
+open import Data.Nat.Type
+open import Data.Nat.eq
+open import Data.Nat.ord
+open import Data.List.Type
+open import Data.Bool.Type
+open import Data.Bool.and
+
+-- Helper function to create a balanced tree
+balanced-tree : AVLTree Nat
+balanced-tree = from-list (3 :: 2 :: 4 :: [])
+
+-- Test: Insert into an empty tree
+test-insert-empty : insert 1 empty === Node 1 zero empty empty
+test-insert-empty = refl
+
+-- Test: Insert into a balanced tree (no rotation needed)
+test-insert-no-rotation : insert 5 balanced-tree ===
+  Node 3 +one (Node 2 zero empty empty) (Node 4 +one empty (Node 5 zero empty empty))
+test-insert-no-rotation = refl
+
+-- Test: Insert triggering a left rotation
+test-insert-left-rotation : insert 5 (insert 6 balanced-tree) ===
+  Node 3 +one (Node 2 zero empty empty) (Node 5 zero (Node 4 zero empty empty) (Node 6 zero empty empty))
+test-insert-left-rotation = refl
+
+-- Test: Insert triggering a right rotation
+test-insert-right-rotation : insert 1 (insert 0 balanced-tree) ===
+  Node 3 -one (Node 1 zero (Node 0 zero empty empty) (Node 2 zero empty empty)) (Node 4 zero empty empty)
+test-insert-right-rotation = refl
+
+-- Test: Inserting a duplicate value
+test-insert-duplicate : insert 2 balanced-tree === balanced-tree
+test-insert-duplicate = refl
+
+-- Test: Check if the tree remains balanced after insertions
+test-balanced-after-insertions : is-balanced? (insert 6 (insert 5 (insert 4 (insert 0 balanced-tree)))) === True
+test-balanced-after-insertions = refl

--- a/Data/AVLTree/Test/is-balanced.agda
+++ b/Data/AVLTree/Test/is-balanced.agda
@@ -1,0 +1,32 @@
+module Data.AVLTree.Test.is-balanced where
+
+open import Data.AVLTree.Type
+open import Data.AVLTree.Balance.Type
+open import Data.AVLTree.height
+open import Data.Nat.Type
+open import Data.Nat.eq
+open import Data.Nat.sub
+open import Data.Bool.Type
+open import Data.Bool.if
+open import Data.Maybe.Type
+
+-- Checks if an AVL tree is balanced.
+-- - tree: The AVL tree to check.
+-- = Some height if the tree is balanced, None otherwise.
+is-balanced : ∀ {A : Set} → AVLTree A → Maybe Nat
+is-balanced Leaf = Some Zero
+is-balanced (Node _ balance left right) with is-balanced left | is-balanced right
+... | None | _    = None
+... | _    | None = None
+... | Some h-left | Some h-right with balance
+...   | -one = if h-left  == Succ h-right then Some (Succ h-left)  else None
+...   | zero = if h-left  == h-right      then Some (Succ h-left)  else None
+...   | +one = if h-right == Succ h-left  then Some (Succ h-right) else None
+
+-- Wrapper function that returns a boolean for easier use in tests
+-- - tree: The AVL tree to check.
+-- = True if the tree is balanced, False otherwise.
+is-balanced? : ∀ {A : Set} → AVLTree A → Bool
+is-balanced? tree with is-balanced tree
+... | Some _ = True
+... | None   = False

--- a/Data/AVLTree/Test/rotate-left.agda
+++ b/Data/AVLTree/Test/rotate-left.agda
@@ -1,0 +1,71 @@
+module Data.AVLTree.Test.rotate-left where
+
+open import Data.AVLTree.Type
+open import Data.AVLTree.Balance.Type
+open import Data.AVLTree.Balance.rotate-left
+open import Data.AVLTree.empty
+open import Data.Equal.Type
+open import Data.Nat.Type
+open import Data.Nat.eq
+open import Data.Pair.Type
+open import Data.Bool.Type
+
+-- Test case 1: Rotate left with right child having +one balance
+test-rotate-left-1 : 
+  rotate-left (Node 1 +one 
+                 empty 
+                 (Node 2 +one 
+                   empty 
+                   empty)) 
+  ===
+  (Node 2 zero 
+    (Node 1 zero 
+      empty 
+      empty) 
+    empty , False)
+test-rotate-left-1 = refl
+
+-- Test case 2: Rotate left with right child having zero balance
+test-rotate-left-2 : 
+  rotate-left (Node 1 +one 
+                 empty 
+                 (Node 2 zero 
+                   empty 
+                   empty)) 
+  ===
+  (Node 2 -one 
+    (Node 1 +one 
+      empty 
+      empty) 
+    empty , True)
+test-rotate-left-2 = refl
+
+-- Test case 3: Rotate left with right child having -one balance
+test-rotate-left-3 : 
+  rotate-left (Node 1 +one 
+                 empty 
+                 (Node 3 -one 
+                   (Node 2 zero 
+                     empty 
+                     empty) 
+                   empty)) 
+  ===
+  (Node 2 zero 
+    (Node 1 zero 
+      empty 
+      empty) 
+    (Node 3 zero 
+      empty 
+      empty) , False)
+test-rotate-left-3 = refl
+
+-- Test case 4: Invalid rotation (should return the same tree)
+test-rotate-left-4 : 
+  rotate-left (Node 1 zero 
+                 empty 
+                 empty) 
+  ===
+  (Node 1 zero 
+    empty 
+    empty , False)
+test-rotate-left-4 = refl

--- a/Data/AVLTree/Test/rotate-right.agda
+++ b/Data/AVLTree/Test/rotate-right.agda
@@ -1,0 +1,71 @@
+module Data.AVLTree.Test.rotate-right where
+
+open import Data.AVLTree.Type
+open import Data.AVLTree.Balance.Type
+open import Data.AVLTree.Balance.rotate-right
+open import Data.AVLTree.empty
+open import Data.Equal.Type
+open import Data.Nat.Type
+open import Data.Nat.eq
+open import Data.Pair.Type
+open import Data.Bool.Type
+
+-- Test case 1: Rotate right with left child having -one balance
+test-rotate-right-1 : 
+  rotate-right (Node 2 -one 
+                  (Node 1 -one 
+                    empty 
+                    empty)
+                  empty) 
+  ===
+  (Node 1 zero 
+    empty
+    (Node 2 zero 
+      empty 
+      empty) , False)
+test-rotate-right-1 = refl
+
+-- Test case 2: Rotate right with left child having zero balance
+test-rotate-right-2 : 
+  rotate-right (Node 2 -one 
+                  (Node 1 zero 
+                    empty 
+                    empty)
+                  empty) 
+  ===
+  (Node 1 +one 
+    empty
+    (Node 2 -one 
+      empty 
+      empty) , True)
+test-rotate-right-2 = refl
+
+-- Test case 3: Rotate right with left child having +one balance
+test-rotate-right-3 : 
+  rotate-right (Node 3 -one 
+                  (Node 1 +one 
+                    empty 
+                    (Node 2 zero 
+                      empty 
+                      empty))
+                  empty) 
+  ===
+  (Node 2 zero 
+    (Node 1 zero 
+      empty 
+      empty)
+    (Node 3 zero 
+      empty 
+      empty) , False)
+test-rotate-right-3 = refl
+
+-- Test case 4: Invalid rotation (should return the same tree)
+test-rotate-right-4 : 
+  rotate-right (Node 1 zero 
+                  empty 
+                  empty) 
+  ===
+  (Node 1 zero 
+    empty 
+    empty , False)
+test-rotate-right-4 = refl

--- a/Data/AVLTree/Type.agda
+++ b/Data/AVLTree/Type.agda
@@ -1,0 +1,9 @@
+module Data.AVLTree.Type where
+
+open import Data.AVLTree.Balance.Type
+
+-- Defines an AVL tree datatype.
+-- - A: The type of values stored in the tree.
+data AVLTree (A : Set) : Set where
+  Leaf : AVLTree A
+  Node : (value : A) → (balance : Balance) → (left : AVLTree A) → (right : AVLTree A) → AVLTree A

--- a/Data/AVLTree/delete-maximum.agda
+++ b/Data/AVLTree/delete-maximum.agda
@@ -10,7 +10,13 @@ open import Data.Pair.Type
 open import Data.Maybe.Type
 open import Data.Function.case
 
--- returns the maximum element and true if the height decreased
+-- Deletes the maximum element from an AVL tree, maintaining balance.
+-- - tree: The AVL tree to delete from.
+-- = A pair containing:
+--   1. Another pair with:
+--      a. The new AVL tree with the maximum element removed.
+--      b. The maximum element that was removed (or None if the tree was empty).
+--   2. A boolean indicating whether the height of the tree decreased.
 delete-maximum : ∀ {A : Set} → {{OrdA : Ord A}} → AVLTree A → Pair (Pair (AVLTree A) (Maybe A)) Bool
 delete-maximum Leaf = (empty , None) , False
 delete-maximum (Node v    _       left Leaf)  = (left , Some v) , True

--- a/Data/AVLTree/delete-maximum.agda
+++ b/Data/AVLTree/delete-maximum.agda
@@ -1,0 +1,24 @@
+module Data.AVLTree.delete-maximum where
+
+open import Data.AVLTree.Type
+open import Data.AVLTree.empty
+open import Data.AVLTree.Balance.Type
+open import Data.AVLTree.Balance.rotate-right
+open import Data.Trait.Ord
+open import Data.Bool.Type
+open import Data.Pair.Type
+open import Data.Maybe.Type
+open import Data.Function.case
+
+-- returns the maximum element and true if the height decreased
+delete-maximum : ∀ {A : Set} → {{OrdA : Ord A}} → AVLTree A → Pair (Pair (AVLTree A) (Maybe A)) Bool
+delete-maximum Leaf = (empty , None) , False
+delete-maximum (Node v    _       left Leaf)  = (left , Some v) , True
+delete-maximum (Node curr balance left right) =
+  let ((other , v) , is-smaller) = delete-maximum right in
+  case (is-smaller , balance) of λ where
+    (False , _   ) → (Node curr balance left other , v) , False
+    (True  , +one) → (Node curr zero    left other , v) , True
+    (True  , zero) → (Node curr -one    left other , v) , False
+    (True  , -one) → let (node , height) = rotate-right (Node curr -one left other)
+                     in  (node , v) , height

--- a/Data/AVLTree/delete.agda
+++ b/Data/AVLTree/delete.agda
@@ -15,6 +15,10 @@ open import Data.Pair.map-snd
 open import Data.Ordering.Type
 open import Data.Function.case
 
+-- Deletes a value from an AVL tree, maintaining balance.
+-- - v: The value to delete.
+-- - t: The AVL tree to delete from.
+-- = A new AVL tree with the value deleted and balance maintained.
 delete : ∀ {A : Set} → {{OrdA : Ord A}} → A → AVLTree A → AVLTree A
 delete v t = Pair.fst (delete' v t) where
   -- returns True if the height decreased

--- a/Data/AVLTree/delete.agda
+++ b/Data/AVLTree/delete.agda
@@ -1,0 +1,49 @@
+module Data.AVLTree.delete where
+
+open import Data.AVLTree.Type
+open import Data.AVLTree.empty
+open import Data.AVLTree.delete-maximum
+open import Data.AVLTree.Balance.Type
+open import Data.AVLTree.Balance.rotate-left
+open import Data.AVLTree.Balance.rotate-right
+open import Data.Trait.Ord
+open import Data.Maybe.Type
+open import Data.Bool.Type
+open import Data.Bool.not
+open import Data.Pair.Type
+open import Data.Pair.map-snd
+open import Data.Ordering.Type
+open import Data.Function.case
+
+delete : ∀ {A : Set} → {{OrdA : Ord A}} → A → AVLTree A → AVLTree A
+delete v t = Pair.fst (delete' v t) where
+  -- returns True if the height decreased
+  delete' : ∀ {A : Set} → {{OrdA : Ord A}} → A → AVLTree A → Pair (AVLTree A) Bool
+  delete' _ Leaf = empty , False
+  delete' v (Node curr balance left right) with compare v curr
+  ... | EQ =
+    case left of λ where
+      Leaf → left , True
+      _    →
+        let ((other , deleted) , is-smaller) = delete-maximum left in
+        case (deleted , is-smaller , balance) of λ where
+          -- deleted == None cannot happen
+          (None , _ , _) → Node curr balance left right , False
+          (Some got , False , _   ) → Node got balance other right , False
+          (Some got , True  , -one) → Node got zero    other right , True
+          (Some got , True  , zero) → Node got +one    other right , False
+          (Some got , True  , +one) → map-snd not (rotate-left (Node got +one other right))
+  ... | LT =
+    let (other , is-smaller) = delete' v left in
+    case (is-smaller , balance) of λ where
+      (False , _   ) → Node curr balance other right , False
+      (True  , -one) → Node curr zero    other right , True
+      (True  , zero) → Node curr +one    other right , False
+      (True  , +one) → map-snd not (rotate-left (Node curr +one other right))
+  ... | GT =
+    let (other , is-smaller) = delete' v right in
+    case (is-smaller , balance) of λ where
+      (False , _   ) → Node curr balance left other , False
+      (True  , +one) → Node curr zero    left other , True
+      (True  , zero) → Node curr -one    left other , False
+      (True  , -one) → map-snd not (rotate-right (Node curr -one left other))

--- a/Data/AVLTree/empty.agda
+++ b/Data/AVLTree/empty.agda
@@ -3,5 +3,7 @@ module Data.AVLTree.empty where
 open import Data.AVLTree.Type
 open import Data.AVLTree.Balance.Type
 
+-- Creates an empty AVL tree.
+-- = An empty AVL tree.
 empty : ∀ {A : Set} → AVLTree A
 empty = Leaf

--- a/Data/AVLTree/empty.agda
+++ b/Data/AVLTree/empty.agda
@@ -1,0 +1,7 @@
+module Data.AVLTree.empty where
+
+open import Data.AVLTree.Type
+open import Data.AVLTree.Balance.Type
+
+empty : ∀ {A : Set} → AVLTree A
+empty = Leaf

--- a/Data/AVLTree/from-list.agda
+++ b/Data/AVLTree/from-list.agda
@@ -1,0 +1,14 @@
+module Data.AVLTree.from-list where
+
+open import Data.AVLTree.Type
+open import Data.AVLTree.insert
+open import Data.AVLTree.empty
+open import Data.List.Type
+open import Data.List.foldr
+open import Data.Trait.Ord
+
+-- Constructs an AVL tree from a list of elements.
+-- - xs: The input list of elements.
+-- = An AVL tree containing all elements from the input list.
+from-list : ∀ {A : Set} → {{OrdA : Ord A}} → List A → AVLTree A
+from-list = foldr insert empty

--- a/Data/AVLTree/has-key.agda
+++ b/Data/AVLTree/has-key.agda
@@ -1,0 +1,17 @@
+module Data.AVLTree.has-key where
+
+open import Data.AVLTree.Type
+open import Data.Bool.Type
+open import Data.Trait.Ord
+open import Data.Ordering.Type
+
+-- Checks if a key exists in the AVL tree.
+-- - key: The key to search for.
+-- - tree: The AVL tree to search in.
+-- = True if the key is found, False otherwise.
+has-key : ∀ {A : Set} → {{OrdA : Ord A}} → A → AVLTree A → Bool
+has-key _ Leaf = False
+has-key key (Node value _ left right) with compare key value
+... | LT = has-key key left
+... | EQ = True
+... | GT = has-key key right

--- a/Data/AVLTree/height.agda
+++ b/Data/AVLTree/height.agda
@@ -1,0 +1,12 @@
+module Data.AVLTree.height where
+
+open import Data.AVLTree.Type
+open import Data.Nat.Type
+open import Data.Nat.max
+
+-- Calculates the height of an AVL tree.
+-- - tree: The AVL tree to calculate the height of.
+-- = The height of the tree (number of levels).
+height : ∀ {A : Set} → AVLTree A → Nat
+height Leaf = Zero
+height (Node _ _ left right) = Succ (max (height left) (height right))

--- a/Data/AVLTree/insert.agda
+++ b/Data/AVLTree/insert.agda
@@ -11,6 +11,10 @@ open import Data.Pair.Type
 open import Data.Ordering.Type
 open import Data.Function.case
 
+-- Inserts a value into an AVL tree, maintaining balance.
+-- - v: The value to insert.
+-- - t: The AVL tree to insert into.
+-- = A new AVL tree with the value inserted and balance maintained.
 insert : ∀ {A : Set} → {{OrdA : Ord A}} → A → AVLTree A → AVLTree A
 insert v t = Pair.fst (insert' v t) where
   -- returns True if the height increased
@@ -32,4 +36,3 @@ insert v t = Pair.fst (insert' v t) where
       (True  , -one) → Node curr zero    left other , False
       (True  , zero) → Node curr +one    left other , True
       (True  , +one) → rotate-left (Node curr +one left other)
- 

--- a/Data/AVLTree/insert.agda
+++ b/Data/AVLTree/insert.agda
@@ -36,3 +36,12 @@ insert v t = Pair.fst (insert' v t) where
       (True  , -one) → Node curr zero    left other , False
       (True  , zero) → Node curr +one    left other , True
       (True  , +one) → rotate-left (Node curr +one left other)
+
+-- Infix notation for inserting an element into an AVL tree.
+-- - x: The value to insert.
+-- - t: The AVL tree to insert into.
+-- = A new AVL tree with the value inserted and balance maintained.
+_::>_ : ∀ {A : Set} → {{OrdA : Ord A}} → A → AVLTree A → AVLTree A
+_::>_ = insert
+
+infixr 5 _::>_

--- a/Data/AVLTree/insert.agda
+++ b/Data/AVLTree/insert.agda
@@ -1,0 +1,35 @@
+module Data.AVLTree.insert where
+
+open import Data.AVLTree.Type
+open import Data.AVLTree.empty
+open import Data.AVLTree.Balance.Type
+open import Data.AVLTree.Balance.rotate-left
+open import Data.AVLTree.Balance.rotate-right
+open import Data.Trait.Ord
+open import Data.Bool.Type
+open import Data.Pair.Type
+open import Data.Ordering.Type
+open import Data.Function.case
+
+insert : ∀ {A : Set} → {{OrdA : Ord A}} → A → AVLTree A → AVLTree A
+insert v t = Pair.fst (insert' v t) where
+  -- returns True if the height increased
+  insert' : ∀ {A : Set} → {{OrdA : Ord A}} → A → AVLTree A → Pair (AVLTree A) Bool
+  insert' v Leaf = Node v zero empty empty , True
+  insert' v (Node curr balance left right) with compare v curr
+  ... | EQ = Node curr balance left right , False
+  ... | LT =
+    let (other , is-higher) = insert' v left in
+    case (is-higher , balance) of λ where
+      (False , _   ) → Node curr balance other right , False
+      (True  , +one) → Node curr zero    other right , False
+      (True  , zero) → Node curr -one    other right , True
+      (True  , -one) → rotate-right (Node curr -one other right)
+  ... | GT =
+    let (other , is-higher) = insert' v right in
+    case (is-higher , balance) of λ where
+      (False , _   ) → Node curr balance left other , False
+      (True  , -one) → Node curr zero    left other , False
+      (True  , zero) → Node curr +one    left other , True
+      (True  , +one) → rotate-left (Node curr +one left other)
+ 

--- a/Data/AVLTree/singleton.agda
+++ b/Data/AVLTree/singleton.agda
@@ -3,5 +3,8 @@ module Data.AVLTree.singleton where
 open import Data.AVLTree.Type
 open import Data.AVLTree.Balance.Type
 
+-- Creates a singleton AVL tree with one element.
+-- - x: The value to be stored in the tree.
+-- = An AVL tree containing only the given value.
 singleton : ∀ {A : Set} → A → AVLTree A
 singleton x = Node x zero Leaf Leaf

--- a/Data/AVLTree/singleton.agda
+++ b/Data/AVLTree/singleton.agda
@@ -1,0 +1,7 @@
+module Data.AVLTree.singleton where
+
+open import Data.AVLTree.Type
+open import Data.AVLTree.Balance.Type
+
+singleton : ∀ {A : Set} → A → AVLTree A
+singleton x = Node x zero Leaf Leaf

--- a/Data/AVLTree/to-list.agda
+++ b/Data/AVLTree/to-list.agda
@@ -1,0 +1,13 @@
+module Data.AVLTree.to-list where
+
+open import Data.AVLTree.Type
+open import Data.List.Type
+open import Data.List.append
+
+-- Converts an AVL tree to a sorted list.
+-- - tree: The AVL tree to convert.
+-- = A list containing all elements from the tree in ascending order.
+to-list : ∀ {A : Set} → AVLTree A → List A
+to-list Leaf = []
+to-list (Node value _ left right) =
+  to-list left ++ (value :: to-list right)

--- a/Data/Pair/map-fst.agda
+++ b/Data/Pair/map-fst.agda
@@ -1,0 +1,10 @@
+module Data.Pair.map-fst where
+
+open import Data.Pair.Type
+
+-- Applies a function to the first element of a Pair.
+-- - fn: The function to be applied to the first element.
+-- - pair: The input Pair.
+-- = A new Pair with the first element unchanged and the first element transformed by fn.
+map-fst : ∀ {A B C : Set} → (A → C) → Pair A B → Pair C B
+map-fst f (x , y) = f x , y

--- a/Data/Pair/map-snd.agda
+++ b/Data/Pair/map-snd.agda
@@ -1,0 +1,10 @@
+module Data.Pair.map-snd where
+
+open import Data.Pair.Type
+
+-- Applies a function to the second element of a Pair.
+-- - fn: The function to be applied to the second element.
+-- - pair: The input Pair.
+-- = A new Pair with the first element unchanged and the second element transformed by fn.
+map-snd : ∀ {A B C : Set} → (B → C) → Pair A B → Pair A C
+map-snd f (x , y) = x , f y


### PR DESCRIPTION
Adds AVL trees. Pre-requisite for implementing ordered maps and ordered sets.

Another approach would have been implementing a verified AVL tree like [in this blog post](https://doisinkidney.com/posts/2018-07-30-verified-avl.html). I'm not sure which approach is more suited to the goals of this project, though I think it is the Haskell-like I wrote.