### PR TITLE
Implement `OrdMap` and `OrdSet`, change `AVL A` to `AVL K V`

### DIFF
--- a/Data/AVL/Balance/rotate-left.agda
+++ b/Data/AVL/Balance/rotate-left.agda
@@ -11,7 +11,7 @@ open import Data.Bool.if
 -- Performs a left rotation on an AVL tree to fix an imbalance of +2.
 -- - tree: The AVL tree to rotate.
 -- = A pair containing the rotated AVL tree and a boolean indicating if the height of the root stayed the same.
-rotate-left : ∀ {A : Set} → AVL A → Pair (AVL A) Bool
+rotate-left : ∀ {K V : Set} → AVL K V → Pair (AVL K V) Bool
 rotate-left
    (Node v₁ +one
       left

--- a/Data/AVL/Balance/rotate-right.agda
+++ b/Data/AVL/Balance/rotate-right.agda
@@ -11,7 +11,7 @@ open import Data.Bool.if
 -- Performs a right rotation on an AVL tree to fix an imbalance of -2.
 -- - tree: The AVL tree to rotate.
 -- = A pair containing the rotated AVL tree and a boolean indicating if the height of the root stayed the same.
-rotate-right : ∀ {A : Set} → AVL A → Pair (AVL A) Bool
+rotate-right : ∀ {K V : Set} → AVL K V → Pair (AVL K V) Bool
 rotate-right
    (Node v₁ -one
       (Node v₂ -one

--- a/Data/AVL/Test/delete-maximum.agda
+++ b/Data/AVL/Test/delete-maximum.agda
@@ -20,44 +20,49 @@ open import Data.Bool.or
 open import Data.Bool.and
 open import Data.Trait.Ord
 open import Data.Nat.lt
+open import Data.Unit.Type
 
 -- Helper function to create a test tree
-create-test-tree : AVL Nat
+create-test-tree : AVL Nat Unit
 create-test-tree =
-  10 ::> 2 ::> 8 ::> 6 ::> 4 ::> 9 ::> 1 ::> 7 ::> 3 ::> 5 ::> empty
+  (10 , unit) ::> (2 , unit) ::> (8 , unit) ::> (6 , unit) ::> (4 , unit) ::>
+   (9 , unit) ::> (1 , unit) ::> (7 , unit) ::> (3 , unit) ::> (5 , unit) ::> empty
 
 -- Test 1: Deleting maximum from an empty tree
-test-empty : ((empty , None) , False) === delete-maximum {Nat} empty
+test-empty : (None , empty , False) === delete-maximum {Nat} {Unit} empty
 test-empty = refl
 
 -- Test 2: Deleting maximum from a single-node tree
-test-single-node : ((empty , Some 5) , True) === delete-maximum (Node 5 zero empty empty)
+test-single-node : (Some (5 , unit) , empty , True) === delete-maximum (Node (5 , unit) zero empty empty)
 test-single-node = refl
 
 -- Test 3: Deleting maximum from a larger tree
-test-larger-tree : to-list (Pair.fst (Pair.fst (delete-maximum create-test-tree))) === (1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: 9 :: [])
+test-larger-tree : to-list (Pair.fst (Pair.snd (delete-maximum create-test-tree))) ===
+                   ((1 , unit) :: (2 , unit) :: (3 , unit) :: (4 , unit) :: (5 , unit) ::
+                    (6 , unit) :: (7 , unit) :: (8 , unit) :: (9 , unit) :: [])
 test-larger-tree = refl
 
 -- Test 4: Checking the maximum value returned
-test-max-value : Some 10 === Pair.snd (Pair.fst (delete-maximum create-test-tree))
+test-max-value : Some (10 , unit) === Pair.fst (delete-maximum create-test-tree)
 test-max-value = refl
 
 -- Test 5: Deleting maximum multiple times
 test-multiple-delete : 
-  let tree₁ = Pair.fst (Pair.fst (delete-maximum create-test-tree))
-      tree₂ = Pair.fst (Pair.fst (delete-maximum tree₁))
-      tree₃ = Pair.fst (Pair.fst (delete-maximum tree₂))
-  in to-list tree₃ === (1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: [])
+  let (_ , tree₁ , _) = delete-maximum create-test-tree
+      (_ , tree₂ , _) = delete-maximum tree₁
+      (_ , tree₃ , _) = delete-maximum tree₂
+  in to-list tree₃ === ((1 , unit) :: (2 , unit) :: (3 , unit) :: (4 , unit) ::
+                        (5 , unit) :: (6 , unit) :: (7 , unit) :: [])
 test-multiple-delete = refl
 
 -- Test 6: Checking if the tree remains balanced after deleting maximum
-test-balanced-after-delete : True === is-balanced (Pair.fst (Pair.fst (delete-maximum create-test-tree)))
+test-balanced-after-delete : True === is-balanced (Pair.fst (Pair.snd (delete-maximum create-test-tree)))
 test-balanced-after-delete = refl
 
 -- Test 7: Checking if the tree remains balanced after multiple deletions
 test-balanced-after-multiple-deletes :
-  let tree₁ = Pair.fst (Pair.fst (delete-maximum create-test-tree))
-      tree₂ = Pair.fst (Pair.fst (delete-maximum tree₁))
-      tree₃ = Pair.fst (Pair.fst (delete-maximum tree₂))
+  let (_ , tree₁ , _) = delete-maximum create-test-tree
+      (_ , tree₂ , _) = delete-maximum tree₁
+      (_ , tree₃ , _) = delete-maximum tree₂
   in True === (is-balanced tree₁ && is-balanced tree₂ && is-balanced tree₃)
 test-balanced-after-multiple-deletes = refl

--- a/Data/AVL/Test/delete.agda
+++ b/Data/AVL/Test/delete.agda
@@ -14,65 +14,69 @@ open import Data.Nat.eq
 open import Data.Nat.ord
 open import Data.List.Type
 open import Data.List.eq
+open import Data.Unit.Type
+open import Data.Unit.eq
+open import Data.Pair.Type
+open import Data.Pair.eq
 
 -- Test 1: Deleting from an empty tree
-test-delete-empty : delete 5 empty === empty
+test-delete-empty : delete 5 (empty {V = Unit}) === empty
 test-delete-empty = refl
 
 -- Test 2: Deleting a non-existent element
-test-delete-non-existent : delete 5 (insert 3 empty) === insert 3 empty
+test-delete-non-existent : delete 5 (insert (3 , unit) empty) === insert (3 , unit) empty
 test-delete-non-existent = refl
 
 -- Test 3: Deleting the root of a single-element tree
-test-delete-root-single : delete 3 (insert 3 empty) === empty
+test-delete-root-single : delete 3 (insert (3 , unit) empty) === empty
 test-delete-root-single = refl
 
 -- Test 4: Deleting from a balanced tree
 test-delete-balanced : 
-  let tree = insert 2 (insert 1 (insert 3 empty))
+  let tree = insert (2 , unit) (insert (1 , unit) (insert (3 , unit) empty))
       result = delete 2 tree
-  in (to-list result == to-list (insert 3 (insert 1 empty))) && is-balanced result === True
+  in (to-list result == to-list (insert (3 , unit) (insert (1 , unit) empty))) && is-balanced result === True
 test-delete-balanced = refl
 
 -- Test 5: Deleting causing a left rotation
 test-delete-left-rotation :
-  let tree = insert 4 (insert 3 (insert 2 (insert 1 empty)))
+  let tree = insert (4 , unit) (insert (3 , unit) (insert (2 , unit) (insert (1 , unit) empty)))
       result = delete 1 tree
   in is-balanced result === True
 test-delete-left-rotation = refl
 
 -- Test 6: Deleting causing a right rotation
 test-delete-right-rotation :
-  let tree = insert 1 (insert 2 (insert 3 (insert 4 empty)))
+  let tree = insert (1 , unit) (insert (2 , unit) (insert (3 , unit) (insert (4 , unit) empty)))
       result = delete 4 tree
   in is-balanced result === True
 test-delete-right-rotation = refl
 
 -- Test 7: Deleting from a larger tree
 test-delete-larger-tree :
-  let tree = insert 5 (insert 3 (insert 7 (insert 2 (insert 4 (insert 6 (insert 8 empty))))))
+  let tree = insert (5 , unit) (insert (3 , unit) (insert (7 , unit) (insert (2 , unit) (insert (4 , unit) (insert (6 , unit) (insert (8 , unit) empty))))))
       result = delete 3 tree
-  in is-balanced result && (to-list result == 2 :: 4 :: 5 :: 6 :: 7 :: 8 :: []) === True
+  in is-balanced result && (to-list result == (2 , unit) :: (4 , unit) :: (5 , unit) :: (6 , unit) :: (7 , unit) :: (8 , unit) :: []) === True
 test-delete-larger-tree = refl
 
 -- Test 8: Multiple deletions
 test-multiple-deletions :
-  let tree = insert 5 (insert 3 (insert 7 (insert 2 (insert 4 (insert 6 (insert 8 empty))))))
+  let tree = insert (5 , unit) (insert (3 , unit) (insert (7 , unit) (insert (2 , unit) (insert (4 , unit) (insert (6 , unit) (insert (8 , unit) empty))))))
       result = delete 4 (delete 7 (delete 2 tree))
-  in is-balanced result && (to-list result == 3 :: 5 :: 6 :: 8 :: []) === True
+  in is-balanced result && (to-list result == (3 , unit) :: (5 , unit) :: (6 , unit) :: (8 , unit) :: []) === True
 test-multiple-deletions = refl
 
 -- Test 9: Deleting all elements
 test-delete-all :
-  let tree = insert 3 (insert 2 (insert 1 empty))
+  let tree = insert (3 , unit) (insert (2 , unit) (insert (1 , unit) empty))
       result = delete 2 (delete 3 (delete 1 tree))
   in result === empty
 test-delete-all = refl
 
 -- Test 10: Deleting and re-inserting
 test-delete-reinsert :
-  let tree = insert 3 (insert 2 (insert 1 empty))
+  let tree = insert (3 , unit) (insert (2 , unit) (insert (1 , unit) empty))
       intermediate = delete 2 tree
-      result = insert 2 intermediate
+      result = insert (2 , unit) intermediate
   in (to-list result == to-list tree) && is-balanced result === True
 test-delete-reinsert = refl

--- a/Data/AVL/Test/has-key.agda
+++ b/Data/AVL/Test/has-key.agda
@@ -9,13 +9,15 @@ open import Data.Bool.Type
 open import Data.Nat.Type
 open import Data.Nat.ord
 open import Data.Trait.Ord
+open import Data.Unit.Type
+open import Data.Pair.Type
 
 -- Sample AVL tree for testing
-sample-tree : AVL Nat
-sample-tree = 5 ::> 3 ::> 7 ::> 1 ::> 4 ::> 6 ::> 8 ::> empty
+sample-tree : AVL Nat Unit
+sample-tree = (5 , unit) ::> (3 , unit) ::> (7 , unit) ::> (1 , unit) ::> (4 , unit) ::> (6 , unit) ::> (8 , unit) ::> empty
 
 -- Test 1: Empty tree
-test-empty : has-key 5 empty === False
+test-empty : has-key 5 (empty {V = Unit}) === False
 test-empty = refl
 
 -- Test 2: Key present in root
@@ -51,9 +53,9 @@ test-not-present-between : has-key 2 sample-tree === False
 test-not-present-between = refl
 
 -- Test 10: Single-element tree (key present)
-test-single-present : has-key 1 (1 ::> empty) === True
+test-single-present : has-key 1 ((1 , unit) ::> empty) === True
 test-single-present = refl
 
 -- Test 11: Single-element tree (key not present)
-test-single-not-present : has-key 2 (1 ::> empty) === False
+test-single-not-present : has-key 2 ((1 , unit) ::> empty) === False
 test-single-not-present = refl

--- a/Data/AVL/Test/insert.agda
+++ b/Data/AVL/Test/insert.agda
@@ -13,34 +13,36 @@ open import Data.Nat.ord
 open import Data.List.Type
 open import Data.Bool.Type
 open import Data.Bool.and
+open import Data.Unit.Type
+open import Data.Pair.Type
 
 -- Helper function to create a balanced tree
-balanced-tree : AVL Nat
-balanced-tree = from-list (3 :: 2 :: 4 :: [])
+balanced-tree : AVL Nat Unit
+balanced-tree = from-list ((3 , unit) :: (2 , unit) :: (4 , unit) :: [])
 
 -- Test: Insert into an empty tree
-test-insert-empty : insert 1 empty === Node 1 zero empty empty
+test-insert-empty : insert (1 , unit) empty === Node (1 , unit) zero empty empty
 test-insert-empty = refl
 
 -- Test: Insert into a balanced tree (no rotation needed)
-test-insert-no-rotation : insert 5 balanced-tree ===
-  Node 3 +one (Node 2 zero empty empty) (Node 4 +one empty (Node 5 zero empty empty))
+test-insert-no-rotation : insert (5 , unit) balanced-tree ===
+  Node (3 , unit) +one (Node (2 , unit) zero empty empty) (Node (4 , unit) +one empty (Node (5 , unit) zero empty empty))
 test-insert-no-rotation = refl
 
 -- Test: Insert triggering a left rotation
-test-insert-left-rotation : insert 5 (insert 6 balanced-tree) ===
-  Node 3 +one (Node 2 zero empty empty) (Node 5 zero (Node 4 zero empty empty) (Node 6 zero empty empty))
+test-insert-left-rotation : insert (5 , unit) (insert (6 , unit) balanced-tree) ===
+  Node (3 , unit) +one (Node (2 , unit) zero empty empty) (Node (5 , unit) zero (Node (4 , unit) zero empty empty) (Node (6 , unit) zero empty empty))
 test-insert-left-rotation = refl
 
 -- Test: Insert triggering a right rotation
-test-insert-right-rotation : insert 1 (insert 0 balanced-tree) ===
-  Node 3 -one (Node 1 zero (Node 0 zero empty empty) (Node 2 zero empty empty)) (Node 4 zero empty empty)
+test-insert-right-rotation : insert (1 , unit) (insert (0 , unit) balanced-tree) ===
+  Node (3 , unit) -one (Node (1 , unit) zero (Node (0 , unit) zero empty empty) (Node (2 , unit) zero empty empty)) (Node (4 , unit) zero empty empty)
 test-insert-right-rotation = refl
 
 -- Test: Inserting a duplicate value
-test-insert-duplicate : insert 2 balanced-tree === balanced-tree
+test-insert-duplicate : insert (2 , unit) balanced-tree === balanced-tree
 test-insert-duplicate = refl
 
 -- Test: Check if the tree remains balanced after insertions
-test-balanced-after-insertions : is-balanced (insert 6 (insert 5 (insert 4 (insert 0 balanced-tree)))) === True
+test-balanced-after-insertions : is-balanced (insert (6 , unit) (insert (5 , unit) (insert (4 , unit) (insert (0 , unit) balanced-tree)))) === True
 test-balanced-after-insertions = refl

--- a/Data/AVL/Test/is-balanced.agda
+++ b/Data/AVL/Test/is-balanced.agda
@@ -13,7 +13,7 @@ open import Data.Maybe.Type
 -- Checks if an AVL tree is balanced.
 -- - tree: The AVL tree to check.
 -- = Some height if the tree is balanced, None otherwise.
-is-balanced' : ∀ {A : Set} → AVL A → Maybe Nat
+is-balanced' : ∀ {K V : Set} → AVL K V → Maybe Nat
 is-balanced' Leaf = Some Zero
 is-balanced' (Node _ balance left right) with is-balanced' left | is-balanced' right
 ... | None | _    = None
@@ -26,7 +26,7 @@ is-balanced' (Node _ balance left right) with is-balanced' left | is-balanced' r
 -- Boolean return for the `is-balanced'` function
 -- - tree: The AVL tree to check.
 -- = True if the tree is balanced, False otherwise.
-is-balanced : ∀ {A : Set} → AVL A → Bool
+is-balanced : ∀ {K V : Set} → AVL K V → Bool
 is-balanced tree with is-balanced' tree
 ... | Some _ = True
 ... | None   = False

--- a/Data/AVL/Test/rotate-left.agda
+++ b/Data/AVL/Test/rotate-left.agda
@@ -9,17 +9,18 @@ open import Data.Nat.Type
 open import Data.Nat.eq
 open import Data.Pair.Type
 open import Data.Bool.Type
+open import Data.Unit.Type
 
 -- Test case 1: Rotate left with right child having +one balance
 test-rotate-left-1 : 
-  rotate-left (Node 1 +one 
+  rotate-left (Node (1 , unit) +one 
                  empty 
-                 (Node 2 +one 
+                 (Node (2 , unit) +one 
                    empty 
                    empty)) 
   ===
-  (Node 2 zero 
-    (Node 1 zero 
+  (Node (2 , unit) zero 
+    (Node (1 , unit) zero 
       empty 
       empty) 
     empty , False)
@@ -27,14 +28,14 @@ test-rotate-left-1 = refl
 
 -- Test case 2: Rotate left with right child having zero balance
 test-rotate-left-2 : 
-  rotate-left (Node 1 +one 
+  rotate-left (Node (1 , unit) +one 
                  empty 
-                 (Node 2 zero 
+                 (Node (2 , unit) zero 
                    empty 
                    empty)) 
   ===
-  (Node 2 -one 
-    (Node 1 +one 
+  (Node (2 , unit) -one 
+    (Node (1 , unit) +one 
       empty 
       empty) 
     empty , True)
@@ -42,30 +43,30 @@ test-rotate-left-2 = refl
 
 -- Test case 3: Rotate left with right child having -one balance
 test-rotate-left-3 : 
-  rotate-left (Node 1 +one 
+  rotate-left (Node (1 , unit) +one 
                  empty 
-                 (Node 3 -one 
-                   (Node 2 zero 
+                 (Node (3 , unit) -one 
+                   (Node (2 , unit) zero 
                      empty 
                      empty) 
                    empty)) 
   ===
-  (Node 2 zero 
-    (Node 1 zero 
+  (Node (2 , unit) zero 
+    (Node (1 , unit) zero 
       empty 
       empty) 
-    (Node 3 zero 
+    (Node (3 , unit) zero 
       empty 
       empty) , False)
 test-rotate-left-3 = refl
 
 -- Test case 4: Invalid rotation (should return the same tree)
 test-rotate-left-4 : 
-  rotate-left (Node 1 zero 
+  rotate-left (Node (1 , unit) zero 
                  empty 
                  empty) 
   ===
-  (Node 1 zero 
+  (Node (1 , unit) zero 
     empty 
     empty , False)
 test-rotate-left-4 = refl

--- a/Data/AVL/Test/rotate-right.agda
+++ b/Data/AVL/Test/rotate-right.agda
@@ -9,63 +9,64 @@ open import Data.Nat.Type
 open import Data.Nat.eq
 open import Data.Pair.Type
 open import Data.Bool.Type
+open import Data.Unit.Type
 
 -- Test case 1: Rotate right with left child having -one balance
 test-rotate-right-1 : 
-  rotate-right (Node 2 -one 
-                  (Node 1 -one 
+  rotate-right (Node (2 , unit) -one 
+                  (Node (1 , unit) -one 
                     empty 
                     empty)
                   empty) 
   ===
-  (Node 1 zero 
+  (Node (1 , unit) zero 
     empty
-    (Node 2 zero 
+    (Node (2 , unit) zero 
       empty 
       empty) , False)
 test-rotate-right-1 = refl
 
 -- Test case 2: Rotate right with left child having zero balance
 test-rotate-right-2 : 
-  rotate-right (Node 2 -one 
-                  (Node 1 zero 
+  rotate-right (Node (2 , unit) -one 
+                  (Node (1 , unit) zero 
                     empty 
                     empty)
                   empty) 
   ===
-  (Node 1 +one 
+  (Node (1 , unit) +one 
     empty
-    (Node 2 -one 
+    (Node (2 , unit) -one 
       empty 
       empty) , True)
 test-rotate-right-2 = refl
 
 -- Test case 3: Rotate right with left child having +one balance
 test-rotate-right-3 : 
-  rotate-right (Node 3 -one 
-                  (Node 1 +one 
+  rotate-right (Node (3 , unit) -one 
+                  (Node (1 , unit) +one 
                     empty 
-                    (Node 2 zero 
+                    (Node (2 , unit) zero 
                       empty 
                       empty))
                   empty) 
   ===
-  (Node 2 zero 
-    (Node 1 zero 
+  (Node (2 , unit) zero 
+    (Node (1 , unit) zero 
       empty 
       empty)
-    (Node 3 zero 
+    (Node (3 , unit) zero 
       empty 
       empty) , False)
 test-rotate-right-3 = refl
 
 -- Test case 4: Invalid rotation (should return the same tree)
 test-rotate-right-4 : 
-  rotate-right (Node 1 zero 
+  rotate-right (Node (1 , unit) zero 
                   empty 
                   empty) 
   ===
-  (Node 1 zero 
+  (Node (1 , unit) zero 
     empty 
     empty , False)
 test-rotate-right-4 = refl

--- a/Data/AVL/Type.agda
+++ b/Data/AVL/Type.agda
@@ -1,9 +1,11 @@
 module Data.AVL.Type where
 
 open import Data.AVL.Balance.Type
+open import Data.Pair.Type
 
 -- Defines an AVL tree datatype.
--- - A: The type of values stored in the tree.
-data AVL (A : Set) : Set where
-  Leaf : AVL A
-  Node : (value : A) → (balance : Balance) → (left : AVL A) → (right : AVL A) → AVL A
+-- - K: The type of keys stored in the tree.
+-- - V: The type of values stored in the tree.
+data AVL (K V : Set) : Set where
+  Leaf : AVL K V
+  Node : (key-value : Pair K V) → (balance : Balance) → (left : AVL K V) → (right : AVL K V) → AVL K V

--- a/Data/AVL/delete-maximum.agda
+++ b/Data/AVL/delete-maximum.agda
@@ -7,6 +7,8 @@ open import Data.AVL.Balance.rotate-right
 open import Data.Trait.Ord
 open import Data.Bool.Type
 open import Data.Pair.Type
+-- We compare Pairs only by their first elements
+open import Data.Pair.ord.fst
 open import Data.Maybe.Type
 open import Data.Function.case
 
@@ -15,16 +17,16 @@ open import Data.Function.case
 -- = A pair containing:
 --   1. Another pair with:
 --      a. The new AVL tree with the maximum element removed.
---      b. The maximum element that was removed (or None if the tree was empty).
+--      b. The maximum key-value pair that was removed (or None if the tree was empty).
 --   2. A boolean indicating whether the height of the tree decreased.
-delete-maximum : ∀ {A : Set} → {{OrdA : Ord A}} → AVL A → Pair (Pair (AVL A) (Maybe A)) Bool
-delete-maximum Leaf = (empty , None) , False
-delete-maximum (Node v    _       left Leaf)  = (left , Some v) , True
+delete-maximum : ∀ {K V : Set} → {{_ : Ord K}} → AVL K V → Pair (Maybe (Pair K V)) (Pair (AVL K V) Bool) 
+delete-maximum Leaf = None , empty , False
+delete-maximum (Node v    _       left Leaf)  = Some v , left , True
 delete-maximum (Node curr balance left right) =
-  let ((other , v) , is-smaller) = delete-maximum right in
+  let (v , other , is-smaller) = delete-maximum right in
   case (is-smaller , balance) of λ where
-    (False , _   ) → (Node curr balance left other , v) , False
-    (True  , +one) → (Node curr zero    left other , v) , True
-    (True  , zero) → (Node curr -one    left other , v) , False
+    (False , _   ) → v , (Node curr balance left other) , False
+    (True  , +one) → v , (Node curr zero    left other) , True
+    (True  , zero) → v , (Node curr -one    left other) , False
     (True  , -one) → let (node , height) = rotate-right (Node curr -one left other)
-                     in  (node , v) , height
+                     in  v , node , height

--- a/Data/AVL/delete.agda
+++ b/Data/AVL/delete.agda
@@ -15,39 +15,39 @@ open import Data.Pair.map-snd
 open import Data.Ordering.Type
 open import Data.Function.case
 
--- Deletes a value from an AVL tree, maintaining balance.
--- - v: The value to delete.
+-- Deletes a key-value pair from an AVL tree, maintaining balance.
+-- - k: The key to delete.
 -- - t: The AVL tree to delete from.
 -- = A new AVL tree with the value deleted and balance maintained.
-delete : ∀ {A : Set} → {{OrdA : Ord A}} → A → AVL A → AVL A
-delete v t = Pair.fst (delete' v t) where
+delete : ∀ {K V : Set} → {{_ : Ord K}} → K → AVL K V → AVL K V
+delete k t = Pair.fst (delete' k t) where
   -- returns True if the height decreased
-  delete' : ∀ {A : Set} → {{OrdA : Ord A}} → A → AVL A → Pair (AVL A) Bool
+  delete' : ∀ {K V : Set} → {{_ : Ord K}} → K → AVL K V → Pair (AVL K V) Bool
   delete' _ Leaf = empty , False
-  delete' v (Node curr balance left right) with compare v curr
+  delete' k (Node (curr-key , curr-val) balance left right) with compare k curr-key
   ... | EQ =
     case left of λ where
       Leaf → left , True
       _    →
-        let ((other , deleted) , is-smaller) = delete-maximum left in
+        let (deleted , other , is-smaller) = delete-maximum left in
         case (deleted , is-smaller , balance) of λ where
           -- deleted == None cannot happen
-          (None , _ , _) → Node curr balance left right , False
+          (None , _ , _) → Node (curr-key , curr-val) balance left right , False
           (Some got , False , _   ) → Node got balance other right , False
           (Some got , True  , -one) → Node got zero    other right , True
           (Some got , True  , zero) → Node got +one    other right , False
           (Some got , True  , +one) → map-snd not (rotate-left (Node got +one other right))
   ... | LT =
-    let (other , is-smaller) = delete' v left in
+    let (other , is-smaller) = delete' k left in
     case (is-smaller , balance) of λ where
-      (False , _   ) → Node curr balance other right , False
-      (True  , -one) → Node curr zero    other right , True
-      (True  , zero) → Node curr +one    other right , False
-      (True  , +one) → map-snd not (rotate-left (Node curr +one other right))
+      (False , _   ) → Node (curr-key , curr-val) balance other right , False
+      (True  , -one) → Node (curr-key , curr-val) zero    other right , True
+      (True  , zero) → Node (curr-key , curr-val) +one    other right , False
+      (True  , +one) → map-snd not (rotate-left (Node (curr-key , curr-val) +one other right))
   ... | GT =
-    let (other , is-smaller) = delete' v right in
+    let (other , is-smaller) = delete' k right in
     case (is-smaller , balance) of λ where
-      (False , _   ) → Node curr balance left other , False
-      (True  , +one) → Node curr zero    left other , True
-      (True  , zero) → Node curr -one    left other , False
-      (True  , -one) → map-snd not (rotate-right (Node curr -one left other))
+      (False , _   ) → Node (curr-key , curr-val) balance left other , False
+      (True  , +one) → Node (curr-key , curr-val) zero    left other , True
+      (True  , zero) → Node (curr-key , curr-val) -one    left other , False
+      (True  , -one) → map-snd not (rotate-right (Node (curr-key , curr-val) -one left other))

--- a/Data/AVL/empty.agda
+++ b/Data/AVL/empty.agda
@@ -5,5 +5,5 @@ open import Data.AVL.Balance.Type
 
 -- Creates an empty AVL tree.
 -- = An empty AVL tree.
-empty : ∀ {A : Set} → AVL A
+empty : ∀ {K V : Set} → AVL K V
 empty = Leaf

--- a/Data/AVL/from-list.agda
+++ b/Data/AVL/from-list.agda
@@ -5,10 +5,11 @@ open import Data.AVL.insert
 open import Data.AVL.empty
 open import Data.List.Type
 open import Data.List.foldr
+open import Data.Pair.Type
 open import Data.Trait.Ord
 
 -- Constructs an AVL tree from a list of elements.
 -- - xs: The input list of elements.
 -- = An AVL tree containing all elements from the input list.
-from-list : ∀ {A : Set} → {{OrdA : Ord A}} → List A → AVL A
+from-list : ∀ {K V : Set} → {{_ : Ord K}} → List (Pair K V) → AVL K V
 from-list = foldr insert empty

--- a/Data/AVL/get-pair.agda
+++ b/Data/AVL/get-pair.agda
@@ -1,0 +1,18 @@
+module Data.AVL.get-pair where
+
+open import Data.AVL.Type
+open import Data.Maybe.Type
+open import Data.Trait.Ord
+open import Data.Ordering.Type
+open import Data.Pair.Type
+
+-- Retrieves a key-value pair from the AVL tree based on the given key.
+-- - key: The key to search for.
+-- - tree: The AVL tree to search in.
+-- = Some key-value pair if the key is found, None otherwise.
+get-pair : ∀ {K V : Set} → {{_ : Ord K}} → K → AVL K V → Maybe (Pair K V)
+get-pair _   Leaf = None
+get-pair key (Node curr _ left right) with compare key (Pair.fst curr)
+... | LT = get-pair key left
+... | EQ = Some curr
+... | GT = get-pair key right

--- a/Data/AVL/get.agda
+++ b/Data/AVL/get.agda
@@ -1,0 +1,18 @@
+module Data.AVL.get where
+
+open import Data.AVL.Type
+open import Data.Maybe.Type
+open import Data.Trait.Ord
+open import Data.Ordering.Type
+open import Data.Pair.Type
+
+-- Retrieves a value associated with a key from the AVL tree.
+-- - key: The key to search for.
+-- - tree: The AVL tree to search in.
+-- = Some value if the key is found, None otherwise.
+get : ∀ {K V : Set} → {{_ : Ord K}} → K → AVL K V → Maybe V
+get _   Leaf = None
+get key (Node curr _ left right) with compare key (Pair.fst curr)
+... | LT = get key left
+... | EQ = Some (Pair.snd curr)
+... | GT = get key right

--- a/Data/AVL/has-key.agda
+++ b/Data/AVL/has-key.agda
@@ -4,14 +4,15 @@ open import Data.AVL.Type
 open import Data.Bool.Type
 open import Data.Trait.Ord
 open import Data.Ordering.Type
+open import Data.Pair.Type
 
 -- Checks if a key exists in the AVL tree.
 -- - key: The key to search for.
 -- - tree: The AVL tree to search in.
 -- = True if the key is found, False otherwise.
-has-key : ∀ {A : Set} → {{OrdA : Ord A}} → A → AVL A → Bool
-has-key _ Leaf = False
-has-key key (Node value _ left right) with compare key value
+has-key : ∀ {K V : Set} → {{_ : Ord K}} → K → AVL K V → Bool
+has-key _   Leaf = False
+has-key key (Node curr _ left right) with compare key (Pair.fst curr)
 ... | LT = has-key key left
 ... | EQ = True
 ... | GT = has-key key right

--- a/Data/AVL/height.agda
+++ b/Data/AVL/height.agda
@@ -7,6 +7,6 @@ open import Data.Nat.max
 -- Calculates the height of an AVL tree.
 -- - tree: The AVL tree to calculate the height of.
 -- = The height of the tree (number of levels).
-height : ∀ {A : Set} → AVL A → Nat
+height : ∀ {K V : Set} → AVL K V → Nat
 height Leaf = Zero
 height (Node _ _ left right) = Succ (max (height left) (height right))

--- a/Data/AVL/insert.agda
+++ b/Data/AVL/insert.agda
@@ -8,17 +8,19 @@ open import Data.AVL.Balance.rotate-right
 open import Data.Trait.Ord
 open import Data.Bool.Type
 open import Data.Pair.Type
+-- We compare Pairs only by their first elements
+open import Data.Pair.ord.fst
 open import Data.Ordering.Type
 open import Data.Function.case
 
 -- Inserts a value into an AVL tree, maintaining balance.
--- - v: The value to insert.
+-- - v: The pair key-value to insert.
 -- - t: The AVL tree to insert into.
 -- = A new AVL tree with the value inserted and balance maintained.
-insert : ∀ {A : Set} → {{OrdA : Ord A}} → A → AVL A → AVL A
+insert : ∀ {K V : Set} → {{_ : Ord K}} → Pair K V → AVL K V → AVL K V
 insert v t = Pair.fst (insert' v t) where
   -- returns True if the height increased
-  insert' : ∀ {A : Set} → {{OrdA : Ord A}} → A → AVL A → Pair (AVL A) Bool
+  insert' : ∀ {K V : Set} → {{_ : Ord K}} → Pair K V → AVL K V → Pair (AVL K V) Bool
   insert' v Leaf = Node v zero empty empty , True
   insert' v (Node curr balance left right) with compare v curr
   ... | EQ = Node curr balance left right , False
@@ -41,7 +43,7 @@ insert v t = Pair.fst (insert' v t) where
 -- - x: The value to insert.
 -- - t: The AVL tree to insert into.
 -- = A new AVL tree with the value inserted and balance maintained.
-_::>_ : ∀ {A : Set} → {{OrdA : Ord A}} → A → AVL A → AVL A
+_::>_ : ∀ {K V : Set} → {{_ : Ord K}} → Pair K V → AVL K V → AVL K V
 _::>_ = insert
 
 infixr 5 _::>_

--- a/Data/AVL/keys.agda
+++ b/Data/AVL/keys.agda
@@ -1,0 +1,16 @@
+module Data.AVL.keys where
+
+open import Data.AVL.Type
+open import Data.List.Type
+open import Data.List.map
+open import Data.List.append
+open import Data.Pair.Type
+open import Data.Pair.fst
+
+-- Extracts all keys from an AVL tree.
+-- - tree: The AVL tree to extract keys from.
+-- = A list containing all keys from the tree.
+keys : ∀ {K V : Set} → AVL K V → List K
+keys Leaf = []
+keys (Node kv _ left right) =
+  keys left ++ (Pair.fst kv :: keys right)

--- a/Data/AVL/singleton.agda
+++ b/Data/AVL/singleton.agda
@@ -2,9 +2,10 @@ module Data.AVL.singleton where
 
 open import Data.AVL.Type
 open import Data.AVL.Balance.Type
+open import Data.Pair.Type
 
 -- Creates a singleton AVL tree with one element.
 -- - x: The value to be stored in the tree.
 -- = An AVL tree containing only the given value.
-singleton : ∀ {A : Set} → A → AVL A
-singleton x = Node x zero Leaf Leaf
+singleton : ∀ {K V : Set} → Pair K V → AVL K V
+singleton p = Node p zero Leaf Leaf

--- a/Data/AVL/to-list.agda
+++ b/Data/AVL/to-list.agda
@@ -1,13 +1,14 @@
 module Data.AVL.to-list where
 
 open import Data.AVL.Type
+open import Data.Pair.Type
 open import Data.List.Type
 open import Data.List.append
 
 -- Converts an AVL tree to a sorted list.
 -- - tree: The AVL tree to convert.
 -- = A list containing all elements from the tree in ascending order.
-to-list : ∀ {A : Set} → AVL A → List A
+to-list : ∀ {K V : Set} → AVL K V → List (Pair K V)
 to-list Leaf = []
 to-list (Node value _ left right) =
   to-list left ++ (value :: to-list right)

--- a/Data/AVL/values.agda
+++ b/Data/AVL/values.agda
@@ -1,0 +1,16 @@
+module Data.AVL.values where
+
+open import Data.AVL.Type
+open import Data.List.Type
+open import Data.List.map
+open import Data.List.append
+open import Data.Pair.Type
+open import Data.Pair.snd
+
+-- Extracts all values from an AVL tree.
+-- - tree: The AVL tree to extract values from.
+-- = A list containing all values from the tree.
+values : ∀ {K V : Set} → AVL K V → List V
+values Leaf = []
+values (Node kv _ left right) =
+  values left ++ (Pair.snd kv :: values right)

--- a/Data/OrdMap/Type.agda
+++ b/Data/OrdMap/Type.agda
@@ -1,0 +1,13 @@
+module Data.OrdMap.Type where
+
+open import Data.AVL.Type
+open import Data.Pair.Type
+
+-- OrdMap is a type alias for AVL trees.
+-- It represents an ordered map (dictionary) data structure.
+-- - K: The type of keys in the map.
+-- - V: The type of values associated with the keys.
+-- The underlying implementation uses an AVL tree for efficient
+-- insertion, deletion, and lookup operations.
+OrdMap : (K V : Set) → Set
+OrdMap K V = AVL K V

--- a/Data/OrdMap/delete.agda
+++ b/Data/OrdMap/delete.agda
@@ -1,0 +1,17 @@
+module Data.OrdMap.delete where
+
+open import Data.AVL.Type
+import Data.AVL.delete as T
+open import Data.OrdMap.Type
+open import Data.Pair.Type
+open import Data.Trait.Ord
+
+-- Deletes a key-value pair from an OrdMap.
+-- This function is a wrapper around the AVL tree delete operation.
+-- - K: The type of keys in the OrdMap.
+-- - V: The type of values in the OrdMap.
+-- - key: The key to be deleted from the OrdMap.
+-- - map: The OrdMap to delete from.
+-- = A new OrdMap with the specified key-value pair removed (if it existed).
+delete : ∀ {K V : Set} → {{_ : Ord K}} → K → OrdMap K V → OrdMap K V
+delete = T.delete

--- a/Data/OrdMap/empty.agda
+++ b/Data/OrdMap/empty.agda
@@ -1,0 +1,9 @@
+module Data.OrdMap.empty where
+
+open import Data.OrdMap.Type
+import Data.AVL.empty as AVL
+
+-- Creates an empty OrdMap.
+-- = An empty OrdMap.
+empty : ∀ {K V : Set} → OrdMap K V
+empty = AVL.empty

--- a/Data/OrdMap/from-list.agda
+++ b/Data/OrdMap/from-list.agda
@@ -1,0 +1,14 @@
+module Data.OrdMap.from-list where
+
+open import Data.OrdMap.Type
+open import Data.List.Type
+open import Data.Pair.Type
+open import Data.AVL.Type
+import Data.AVL.from-list as T
+open import Data.Trait.Ord
+
+-- Converts a list of key-value pairs to an OrdMap.
+-- - pairs: A list of key-value pairs.
+-- = An OrdMap containing all the key-value pairs from the input list.
+from-list : ∀ {K V : Set} → {{_ : Ord K}} → List (Pair K V) → OrdMap K V
+from-list = T.from-list

--- a/Data/OrdMap/get-pair.agda
+++ b/Data/OrdMap/get-pair.agda
@@ -1,0 +1,19 @@
+module Data.OrdMap.get-pair where
+
+open import Data.OrdMap.Type
+open import Data.Maybe.Type
+open import Data.Pair.Type
+open import Data.Trait.Ord
+import Data.AVL.get-pair as AVL
+
+-- Retrieves a key-value pair from the OrdMap based on the given key.
+-- - K: The type of keys in the OrdMap.
+-- - V: The type of values in the OrdMap.
+-- - Ord K: An instance of the Ord typeclass for the key type.
+-- - key: The key to search for.
+-- - map: The OrdMap to search in.
+-- = Maybe (Pair K V), where:
+--   - Some (key, value) if the key is found with its associated value
+--   - None if the key is not found in the map
+get-pair : ∀ {K V : Set} → {{_ : Ord K}} → K → OrdMap K V → Maybe (Pair K V)
+get-pair = AVL.get-pair

--- a/Data/OrdMap/get.agda
+++ b/Data/OrdMap/get.agda
@@ -1,0 +1,19 @@
+module Data.OrdMap.get where
+
+open import Data.OrdMap.Type
+open import Data.Maybe.Type
+open import Data.Pair.Type
+open import Data.Trait.Ord
+import Data.AVL.get as AVL
+
+-- Retrieves the value associated with a given key in the OrdMap.
+-- - K: The type of keys in the OrdMap.
+-- - V: The type of values in the OrdMap.
+-- - Ord K: An instance of the Ord typeclass for the key type.
+-- - key: The key to look up.
+-- - map: The OrdMap to search in.
+-- = Maybe V, where:
+--   - Some v if the key is found with associated value v
+--   - None if the key is not found in the map
+get : ∀ {K V : Set} → {{_ : Ord K}} → K → OrdMap K V → Maybe V
+get = AVL.get

--- a/Data/OrdMap/has-key.agda
+++ b/Data/OrdMap/has-key.agda
@@ -1,0 +1,16 @@
+module Data.OrdMap.has-key where
+
+open import Data.OrdMap.Type
+open import Data.AVL.Type
+import Data.AVL.has-key as AVL
+open import Data.Pair.Type
+open import Data.Bool.Type
+open import Data.Trait.Ord
+open import Data.Pair.ord.fst
+
+-- Checks if a key exists in the OrdMap.
+-- - key: The key to search for.
+-- - map: The OrdMap to search in.
+-- = True if the key is found, False otherwise.
+has-key : ∀ {K V : Set} → {{_ : Ord K}} → K → OrdMap K V → Bool
+has-key = AVL.has-key

--- a/Data/OrdMap/insert.agda
+++ b/Data/OrdMap/insert.agda
@@ -1,0 +1,19 @@
+module Data.OrdMap.insert where
+
+open import Data.AVL.Type
+import Data.AVL.insert as AVL
+open import Data.OrdMap.Type
+open import Data.Pair.Type
+open import Data.Trait.Ord
+
+-- Inserts a key-value pair into an OrdMap.
+-- This function is a wrapper around the AVL tree insert operation.
+-- - K: The type of keys in the OrdMap.
+-- - V: The type of values in the OrdMap.
+-- - Ord K: An instance of the Ord typeclass for the key type.
+-- - pair: The key-value pair to be inserted into the OrdMap.
+-- - map: The OrdMap to insert into.
+-- = A new OrdMap with the specified key-value pair inserted or updated.
+insert : ∀ {K V : Set} → {{_ : Ord K}} →
+         Pair K V → OrdMap K V → OrdMap K V
+insert = AVL.insert

--- a/Data/OrdMap/keys.agda
+++ b/Data/OrdMap/keys.agda
@@ -1,0 +1,11 @@
+module Data.OrdMap.keys where
+
+open import Data.OrdMap.Type
+open import Data.List.Type
+import Data.AVL.keys as AVL
+
+-- Extracts all keys from an OrdMap.
+-- - map: The OrdMap to extract keys from.
+-- = A list containing all keys from the map.
+keys : ∀ {K V : Set} → OrdMap K V → List K
+keys = AVL.keys

--- a/Data/OrdMap/singleton.agda
+++ b/Data/OrdMap/singleton.agda
@@ -1,0 +1,15 @@
+module Data.OrdMap.singleton where
+
+open import Data.OrdMap.Type
+import Data.AVL.singleton as AVL
+open import Data.Pair.Type
+open import Data.Trait.Ord
+
+-- Creates an OrdMap containing a single key-value pair.
+-- - K: The type of the key.
+-- - V: The type of the value.
+-- - Ord K: An instance of the Ord typeclass for the key type.
+-- - key-value: The key-value pair for the single entry.
+-- = A new OrdMap containing only the given key-value pair.
+singleton : ∀ {K V : Set} → {{_ : Ord K}} → Pair K V → OrdMap K V
+singleton = AVL.singleton

--- a/Data/OrdMap/to-list.agda
+++ b/Data/OrdMap/to-list.agda
@@ -1,0 +1,13 @@
+module Data.OrdMap.to-list where
+
+open import Data.OrdMap.Type
+open import Data.List.Type
+open import Data.Pair.Type
+open import Data.AVL.Type
+import Data.AVL.to-list as AVL
+
+-- Converts an OrdMap to a sorted list of key-value pairs.
+-- - map: The OrdMap to convert.
+-- = A list containing all key-value pairs from the map in ascending order of keys.
+to-list : ∀ {K V : Set} → OrdMap K V → List (Pair K V)
+to-list = AVL.to-list

--- a/Data/OrdMap/values.agda
+++ b/Data/OrdMap/values.agda
@@ -1,0 +1,11 @@
+module Data.OrdMap.values where
+
+open import Data.OrdMap.Type
+open import Data.List.Type
+import Data.AVL.values as AVL
+
+-- Extracts all values from an OrdMap.
+-- - map: The OrdMap to extract values from.
+-- = A list containing all values from the map.
+values : ∀ {K V : Set} → OrdMap K V → List V
+values = AVL.values

--- a/Data/OrdSet/Type.agda
+++ b/Data/OrdSet/Type.agda
@@ -1,0 +1,12 @@
+module Data.OrdSet.Type where
+
+open import Data.AVL.Type
+open import Data.Unit.Type
+
+-- OrdSet is a type alias for AVL trees with Unit as the value type.
+-- It represents an ordered set data structure.
+-- - V: The type of elements in the set.
+-- The underlying implementation uses an AVL tree for efficient
+-- insertion, deletion, and lookup operations.
+OrdSet : (V : Set) → Set
+OrdSet V = AVL V Unit

--- a/Data/OrdSet/contains.agda
+++ b/Data/OrdSet/contains.agda
@@ -1,0 +1,13 @@
+module Data.OrdSet.contains where
+
+open import Data.OrdSet.Type
+open import Data.Bool.Type
+open import Data.Trait.Ord
+import Data.AVL.has-key as AVL
+
+-- Checks if an element is present in the OrdSet.
+-- - elem: The element to search for.
+-- - set: The OrdSet to search in.
+-- = True if the element is found, False otherwise.
+contains : ∀ {V : Set} → {{_ : Ord V}} → V → OrdSet V → Bool
+contains = AVL.has-key

--- a/Data/OrdSet/delete.agda
+++ b/Data/OrdSet/delete.agda
@@ -1,0 +1,15 @@
+module Data.OrdSet.delete where
+
+open import Data.OrdSet.Type
+open import Data.Trait.Ord
+import Data.AVL.delete as AVL
+
+-- Deletes an element from an OrdSet.
+-- This function is a wrapper around the AVL tree delete operation.
+-- - V: The type of elements in the OrdSet.
+-- - Ord V: An instance of the Ord typeclass for the element type.
+-- - value: The element to be deleted from the OrdSet.
+-- - set: The OrdSet to delete from.
+-- = A new OrdSet with the specified element removed (if it existed).
+delete : ∀ {V : Set} → {{_ : Ord V}} → V → OrdSet V → OrdSet V
+delete = AVL.delete

--- a/Data/OrdSet/empty.agda
+++ b/Data/OrdSet/empty.agda
@@ -1,0 +1,9 @@
+module Data.OrdSet.empty where
+
+open import Data.OrdSet.Type
+import Data.AVL.empty as AVL
+
+-- Creates an empty OrdSet.
+-- = An empty OrdSet.
+empty : ∀ {V : Set} → OrdSet V
+empty = AVL.empty

--- a/Data/OrdSet/from-list.agda
+++ b/Data/OrdSet/from-list.agda
@@ -1,0 +1,15 @@
+module Data.OrdSet.from-list where
+
+open import Data.OrdSet.Type
+open import Data.List.Type
+open import Data.List.map
+open import Data.Pair.Type
+open import Data.Unit.Type
+open import Data.Trait.Ord
+import Data.AVL.from-list as T
+
+-- Converts a list of elements to an OrdSet.
+-- - elements: A list of elements to be added to the set.
+-- = An OrdSet containing all the unique elements from the input list.
+from-list : ∀ {V : Set} → {{_ : Ord V}} → List V → OrdSet V
+from-list l = T.from-list (map (λ v → (v , unit)) l)

--- a/Data/OrdSet/insert.agda
+++ b/Data/OrdSet/insert.agda
@@ -1,0 +1,27 @@
+module Data.OrdSet.insert where
+
+open import Data.OrdSet.Type
+open import Data.Unit.Type
+open import Data.Pair.Type
+open import Data.Trait.Ord
+import Data.AVL.insert as AVL
+
+-- Inserts an element into an OrdSet.
+-- This function is a wrapper around the AVL tree insert operation.
+-- - V: The type of elements in the OrdSet.
+-- - Ord V: An instance of the Ord typeclass for the element type.
+-- - value: The element to be inserted into the OrdSet.
+-- - set: The OrdSet to insert into.
+-- = A new OrdSet with the specified element inserted.
+insert : ∀ {V : Set} → {{_ : Ord V}} →
+         V → OrdSet V → OrdSet V
+insert value set = AVL.insert (value , unit) set
+
+-- Infix notation for inserting an element into an OrdSet.
+-- - x: The element to insert.
+-- - s: The OrdSet to insert into.
+-- = A new OrdSet with the element inserted.
+_::>_ : ∀ {V : Set} → {{_ : Ord V}} → V → OrdSet V → OrdSet V
+_::>_ = insert
+
+infixr 5 _::>_

--- a/Data/OrdSet/singleton.agda
+++ b/Data/OrdSet/singleton.agda
@@ -1,0 +1,15 @@
+module Data.OrdSet.singleton where
+
+open import Data.OrdSet.Type
+import Data.AVL.singleton as AVL
+open import Data.Unit.Type
+open import Data.Pair.Type
+open import Data.Trait.Ord
+
+-- Creates an OrdSet containing a single element.
+-- - V: The type of the element.
+-- - Ord V: An instance of the Ord typeclass for the element type.
+-- - value: The element to be added to the set.
+-- = A new OrdSet containing only the given element.
+singleton : ∀ {V : Set} → {{_ : Ord V}} → V → OrdSet V
+singleton value = AVL.singleton (value , unit)

--- a/Data/OrdSet/to-list.agda
+++ b/Data/OrdSet/to-list.agda
@@ -1,0 +1,12 @@
+module Data.OrdSet.to-list where
+
+open import Data.OrdSet.Type
+open import Data.List.Type
+open import Data.Pair.Type
+import Data.AVL.keys as AVL
+
+-- Extracts all elements from an OrdSet into a list.
+-- - set: The OrdSet to extract elements from.
+-- = A list containing all elements from the set.
+values : ∀ {V : Set} → OrdSet V → List V
+values set = AVL.keys set

--- a/Data/Pair/ord/both.agda
+++ b/Data/Pair/ord/both.agda
@@ -6,14 +6,11 @@ open import Data.Trait.Ord public
 open import Data.Trait.Ord.default-ord
 
 instance
-  OrdPair : ∀ {A B : Set} → {{_ : Ord A}} → {{_ : Ord B}} → Ord (Pair A B)
-  OrdPair = default-ord cmp where
+  OrdPairBoth : ∀ {A B : Set} → {{_ : Ord A}} → {{_ : Ord B}} → Ord (Pair A B)
+  OrdPairBoth = default-ord cmp where
     cmp : ∀ {A B : Set} → {{_ : Ord A}} → {{_ : Ord B}} → 
           Pair A B → Pair A B → Ordering
     cmp x y with compare (Pair.fst x) (Pair.fst y)
-    cmp x y | EQ with compare (Pair.snd x) (Pair.snd y)
-    ...       | EQ = EQ
-    ...       | LT = LT
-    ...       | GT = GT
+    cmp x y | EQ = compare (Pair.snd x) (Pair.snd y)
     cmp x y | LT = LT
     cmp x y | GT = GT

--- a/Data/Pair/ord/both.agda
+++ b/Data/Pair/ord/both.agda
@@ -1,0 +1,19 @@
+module Data.Pair.ord.both where
+
+open import Data.Pair.Type
+open import Data.Ordering.Type
+open import Data.Trait.Ord public
+open import Data.Trait.Ord.default-ord
+
+instance
+  OrdPair : ∀ {A B : Set} → {{_ : Ord A}} → {{_ : Ord B}} → Ord (Pair A B)
+  OrdPair = default-ord cmp where
+    cmp : ∀ {A B : Set} → {{_ : Ord A}} → {{_ : Ord B}} → 
+          Pair A B → Pair A B → Ordering
+    cmp x y with compare (Pair.fst x) (Pair.fst y)
+    cmp x y | EQ with compare (Pair.snd x) (Pair.snd y)
+    ...       | EQ = EQ
+    ...       | LT = LT
+    ...       | GT = GT
+    cmp x y | LT = LT
+    cmp x y | GT = GT

--- a/Data/Pair/ord/fst.agda
+++ b/Data/Pair/ord/fst.agda
@@ -6,5 +6,5 @@ open import Data.Trait.Ord public
 open import Data.Trait.Ord.default-ord
 
 instance
-  OrdPair : ∀ {A B : Set} → {{_ : Ord A}} → Ord (Pair A B)
-  OrdPair = default-ord λ x y → compare (Pair.fst x) (Pair.fst y)
+  OrdPairFst : ∀ {A B : Set} → {{_ : Ord A}} → Ord (Pair A B)
+  OrdPairFst = default-ord λ x y → compare (Pair.fst x) (Pair.fst y)

--- a/Data/Pair/ord/fst.agda
+++ b/Data/Pair/ord/fst.agda
@@ -1,0 +1,10 @@
+module Data.Pair.ord.fst where
+
+open import Data.Pair.Type
+open import Data.Ordering.Type
+open import Data.Trait.Ord public
+open import Data.Trait.Ord.default-ord
+
+instance
+  OrdPair : ∀ {A B : Set} → {{_ : Ord A}} → Ord (Pair A B)
+  OrdPair = default-ord λ x y → compare (Pair.fst x) (Pair.fst y)

--- a/Data/Pair/ord/snd.agda
+++ b/Data/Pair/ord/snd.agda
@@ -6,5 +6,5 @@ open import Data.Trait.Ord public
 open import Data.Trait.Ord.default-ord
 
 instance
-  OrdPair : ∀ {A B : Set} → {{_ : Ord B}} → Ord (Pair A B)
-  OrdPair = default-ord λ x y → compare (Pair.snd x) (Pair.snd y)
+  OrdPairSnd : ∀ {A B : Set} → {{_ : Ord B}} → Ord (Pair A B)
+  OrdPairSnd = default-ord λ x y → compare (Pair.snd x) (Pair.snd y)

--- a/Data/Pair/ord/snd.agda
+++ b/Data/Pair/ord/snd.agda
@@ -1,0 +1,10 @@
+module Data.Pair.ord.snd where
+
+open import Data.Pair.Type
+open import Data.Ordering.Type
+open import Data.Trait.Ord public
+open import Data.Trait.Ord.default-ord
+
+instance
+  OrdPair : ∀ {A B : Set} → {{_ : Ord B}} → Ord (Pair A B)
+  OrdPair = default-ord λ x y → compare (Pair.snd x) (Pair.snd y)

--- a/Data/Unit/eq.agda
+++ b/Data/Unit/eq.agda
@@ -1,0 +1,12 @@
+module Data.Unit.eq where
+
+open import Data.Unit.Type
+open import Data.Trait.Eq public
+open import Data.Bool.Type
+
+instance
+  EqUnit : Eq Unit
+  EqUnit = record
+    { eq  = λ _ _ → True
+    ; neq = λ _ _ → False
+    }


### PR DESCRIPTION
This PR:
- Changes AVL trees from trees of values to trees of key-value pairs
- Adds multiple Ord instances to compare Pairs (do we think this is a good idea?)
- Adds ordered maps mostly as an alias to AVL
- Adds ordered sets as `AVL V Unit`

In the next PR I want to add more set-like operations such as intersection and union, I think this PR was already complicated enough.