### PR TITLE
Update checking all Agda files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+MAKEFLAGS += --no-builtin-rules --no-builtin-variables
+
+.SUFFIXES :
+
+.PHONY : all clean
+
+all :
+	agda --no-termination-check Main.agda
+
+clean :
+	find . -name '*agdai' -delete

--- a/check_all.sh
+++ b/check_all.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 
-search_path="${1:-./Base}"
+# Ensure the script exits if any command fails
+set -e
 
+SEARCH_PATH="${1:-./Base}"
 OK_OUTPUT=$'Checked.'
 
-find "$search_path" -name "*.agda" -not -path "*.tmp*" -not -path "*/Test/*" | while read -r file; do
-    output=$(agda-cli check "$file" 2>&1)
+find "${SEARCH_PATH}" -name "*.agda" -not -path "*.tmp*" -not -path "*/Test/*" | while read -r file; do
+    output=$(agda-cli check "${file}" 2>&1)
 
-    if [ "${output}" = "$OK_OUTPUT" ]; then
-      echo "Checked $file: OK"
+    if [ "${output}" = "${OK_OUTPUT}" ]; then
+        echo "Checked ${file}: OK"
     else
-      echo -e "\033[31mChecking: $file ERR\033[0m"
-      echo "$output"
+        echo -e "\033[31mChecking: ${file} ERR\033[0m"
+        echo "${output}"
     fi
 done

--- a/parallel_check_all.sh
+++ b/parallel_check_all.sh
@@ -1,19 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Ensure the script exits if any command fails
 set -e
 
+SEARCH_PATH="${1:-./Base}"
 OK_OUTPUT=$'Checked.'
 
 # Function to check a single Agda file
 check_file() {
     file="$1"
-    output=$(agda-cli check "$file" 2>&1)
-    if [ "$output" = "$OK_OUTPUT" ]; then
-        echo "Checked $file: OK"
+    output=$(agda-cli check "${file}" 2>&1)
+    if [ "${output}" = "${OK_OUTPUT}" ]; then
+        echo "Checked ${file}: OK"
     else
-        echo -e "\033[31mChecking: $file ERR\033[0m"
-        echo "$output"
+        echo -e "\033[31mChecking: ${file} ERR\033[0m"
+        echo "${output}"
     fi
 }
 export -f check_file
@@ -21,8 +22,6 @@ export OK_OUTPUT
 
 # Main script
 main() {
-    search_path="${1:-./Base}"
-
     # Check if GNU Parallel is installed
     if ! command -v parallel &> /dev/null; then
         echo "GNU Parallel is not installed. Please install it to run checks in parallel."
@@ -30,7 +29,7 @@ main() {
     fi
 
     # Run Agda checks in parallel
-    find "$search_path" -name "*.agda" -not -path "*.tmp*" -not -path "*/Test/*" -print0 | \
+    find "${SEARCH_PATH}" -name "*.agda" -not -path "*.tmp*" -not -path "*/Test/*" -print0 | \
         parallel -0 -j+0 check_file
 
     echo "All Agda checks passed successfully."

--- a/parallel_check_all.sh
+++ b/parallel_check_all.sh
@@ -3,7 +3,7 @@
 # Ensure the script exits if any command fails
 set -e
 
-OK_OUTPUT=$'Checked.\nNo output'
+OK_OUTPUT=$'Checked.'
 
 # Function to check a single Agda file
 check_file() {


### PR DESCRIPTION
Changed `OK_OUTPUT=$'Checked.\nNo output'` to `OK_OUTPUT=$'Checked.'` in `parallel_check_all.sh`, following changes to `agda-cli`.  Changed cosmetic stuff in shell scripts.

Added `Makefile` to replace shell scripts, which are orders of magnitude slower than invoking Agda once.